### PR TITLE
[zeta W3 SW1] splitPerformerCreditString regex fix + CI template + W2 M-Z13 rebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,109 @@
-name: CI
-on: [push, pull_request]
+name: ci
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
 jobs:
-  build-and-test:
+  build:
+    name: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: npx tsc --noEmit
-      - run: npx vitest run
-      - run: npm run build
+      - name: Type check
+        run: npx tsc --noEmit
+      - name: Build
+        run: npm run build
+
+  vitest:
+    name: vitest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Vitest
+        run: npm run test
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: test-results/
+
+  contract_tests:
+    name: apple_spotify_contract
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Run contract tests (if configured)
+        run: |
+          if grep -q 'test:contracts' package.json; then
+            npm run test:contracts
+          else
+            echo "no contract tests defined; skipping"
+          fi
+        env:
+          SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
+          SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
+          APPLE_MUSIC_KEY_ID: ${{ secrets.APPLE_MUSIC_KEY_ID }}
+          APPLE_MUSIC_TEAM_ID: ${{ secrets.APPLE_MUSIC_TEAM_ID }}
+          APPLE_MUSIC_PRIVATE_KEY: ${{ secrets.APPLE_MUSIC_PRIVATE_KEY }}
+
+  playwright:
+    name: playwright_e2e
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Playwright against maxmeetsmusiccity.com
+        run: npx playwright test --reporter=list
+        env:
+          BASE_URL: https://maxmeetsmusiccity.com
+          SCAN_SECRET: ${{ secrets.SCAN_SECRET }}
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+
+  scan_health_probe:
+    name: scan_health_slim_probe
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Probe slim scan-health endpoint
+        run: |
+          RESPONSE=$(curl -sH "Authorization: Bearer ${{ secrets.SCAN_SECRET }}" https://maxmeetsmusiccity.com/api/scan-health)
+          echo "$RESPONSE" | jq .
+          # Verify slim shape: apple + spotify + tested_at keys present
+          echo "$RESPONSE" | jq -e '.apple and .spotify and .tested_at' > /dev/null || {
+            echo "scan-health slim shape broken"
+            exit 1
+          }
+          # Verify sensitive fields NOT present in slim shape
+          echo "$RESPONSE" | jq -e '.latency == null and .error_details == null' > /dev/null || {
+            echo "scan-health leaked sensitive fields to SCAN_SECRET tier"
+            exit 1
+          }

--- a/api/_scan_intelligence.ts
+++ b/api/_scan_intelligence.ts
@@ -83,6 +83,34 @@ export interface ReleaseVelocity {
   latest_release_date: string | null;
 }
 
+/** Apple `composerName` extracted per track — emitted as a credit-edge
+ *  CANDIDATE (not a confirmed co-write) so Alpha's M20 Credit Corroboration
+ *  Agent can cross-reference against MusicBrainz / ISWC / Spotscraper. Zeta
+ *  is the raw-signal emitter; corroboration lives in the cascade. */
+export interface AppleComposerCredit {
+  track_id: string;                  // apple_isrc_* or apple_track_*
+  track_name: string;
+  primary_artist_id: string | null;  // performer's Apple artist ID
+  primary_artist_name: string;
+  composer_names: string[];          // split from ta.composerName by ,/&/feat
+  source: 'apple_composer_field';
+  release_date: string | null;
+}
+
+/** Split Apple's composerName string into candidate names. Conservative —
+ *  handles the common `Name1, Name2 & Name3` shape without swallowing single
+ *  hyphenated names. */
+export function extractComposerCandidates(composerName: string | null | undefined): string[] {
+  if (!composerName) return [];
+  // Lookahead on (space|end|,|&) after the optional `.` so `feat. ` splits but
+  // `featuring` stays intact. Trailing `\b` alone fails because `.` then space
+  // is non-word→non-word (no boundary).
+  return String(composerName)
+    .split(/,|&|\bfeat\.?(?=\s|$|,|&)|\bft\.?(?=\s|$|,|&)/gi)
+    .map(s => s.trim())
+    .filter(s => s.length > 0 && s.length <= 120);
+}
+
 /** Rate-limit / scan-health incidents for this run. */
 export interface RateLimitIncident {
   platform: 'spotify' | 'apple';
@@ -109,6 +137,7 @@ export interface ScanIntelligence {
   apple_rejections: AppleRejection[];
   stale_spotify_ids: StaleSpotifyId[];
   collaboration_signals: CollaborationSignal[];
+  composer_credits: AppleComposerCredit[];
   release_velocity: ReleaseVelocity[];
   rate_limit_incidents: RateLimitIncident[];
   notes?: string;
@@ -123,6 +152,7 @@ export class IntelligenceAccumulator {
   private appleRejections: AppleRejection[] = [];
   private staleSpotify: StaleSpotifyId[] = [];
   private collaborations: CollaborationSignal[] = [];
+  private composerCredits: AppleComposerCredit[] = [];
   private rateLimit: RateLimitIncident[] = [];
   private releaseVelocityMap = new Map<string, ReleaseVelocity>();
 
@@ -130,6 +160,7 @@ export class IntelligenceAccumulator {
   recordAppleRejection(r: AppleRejection) { this.appleRejections.push(r); }
   recordStaleSpotify(s: StaleSpotifyId) { this.staleSpotify.push(s); }
   recordCollaboration(c: CollaborationSignal) { this.collaborations.push(c); }
+  recordAppleComposerCredit(c: AppleComposerCredit) { this.composerCredits.push(c); }
   recordRateLimit(i: RateLimitIncident) { this.rateLimit.push(i); }
 
   recordTrack(artistName: string, pgId: string | null | undefined, releaseDate: string | null, albumId: string | null) {
@@ -161,6 +192,7 @@ export class IntelligenceAccumulator {
       apple_rejections: this.appleRejections,
       stale_spotify_ids: this.staleSpotify,
       collaboration_signals: this.collaborations,
+      composer_credits: this.composerCredits,
       release_velocity: [...this.releaseVelocityMap.values()],
       rate_limit_incidents: this.rateLimit,
       notes: meta.notes,
@@ -184,6 +216,7 @@ export async function emitIntelligence(artifact: ScanIntelligence): Promise<{ ok
     apple_rejections_count: artifact.apple_rejections.length,
     stale_spotify_ids_count: artifact.stale_spotify_ids.length,
     collaboration_signals_count: artifact.collaboration_signals.length,
+    composer_credits_count: artifact.composer_credits.length,
     release_velocity_count: artifact.release_velocity.length,
     rate_limit_incidents_count: artifact.rate_limit_incidents.length,
     tracks_found: artifact.scope.tracks_found,

--- a/api/_scan_intelligence.ts
+++ b/api/_scan_intelligence.ts
@@ -111,6 +111,18 @@ export function extractComposerCandidates(composerName: string | null | undefine
     .filter(s => s.length > 0 && s.length <= 120);
 }
 
+/** Split a performer credit string (wider delimiter set than composerName —
+ *  includes `with`, `x`, `and` for multi-billed performers). Carries the
+ *  same lookahead fix as `extractComposerCandidates` so `feat.` + space
+ *  splits but `featuring` stays intact. */
+export function splitPerformerCreditString(s: string | null | undefined): string[] {
+  if (!s) return [];
+  return String(s)
+    .split(/,|\bfeat\.?(?=\s|$|,|&)|\bft\.?(?=\s|$|,|&)|\bwith\b|\bx\b|\band\b|&/gi)
+    .map(n => n.trim())
+    .filter(n => n.length > 0);
+}
+
 /** Rate-limit / scan-health incidents for this run. */
 export interface RateLimitIncident {
   platform: 'spotify' | 'apple';

--- a/api/cron-scan-daily.ts
+++ b/api/cron-scan-daily.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
-import { IntelligenceAccumulator, emitIntelligence, type CollaborationSignal, type AppleRejection } from './_scan_intelligence.js';
+import { IntelligenceAccumulator, emitIntelligence, extractComposerCandidates, type CollaborationSignal, type AppleRejection } from './_scan_intelligence.js';
 import { runHealthProbe } from './scan-health.js';
 import { alertSlack } from './_alert.js';
 
@@ -213,7 +213,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const data = await resp.json();
         const tracks = data.tracks || [];
         appleTracks += tracks.length;
-        for (const t of tracks) recordFromTrack(t);
+        for (const t of tracks) {
+          recordFromTrack(t);
+          const composers = extractComposerCandidates(t.composer_name);
+          if (composers.length > 0) {
+            intel.recordAppleComposerCredit({
+              track_id: t.track_id,
+              track_name: t.track_name,
+              primary_artist_id: t.artist_id || null,
+              primary_artist_name: t.artist_names || '',
+              composer_names: composers,
+              source: 'apple_composer_field',
+              release_date: t.release_date || null,
+            });
+          }
+        }
         const rejections = (data.apple_rejections || []) as AppleRejection[];
         for (const r of rejections) intel.recordAppleRejection(r);
         if (tracks.length > 0) {

--- a/api/cron-scan-daily.ts
+++ b/api/cron-scan-daily.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
-import { IntelligenceAccumulator, emitIntelligence, extractComposerCandidates, type CollaborationSignal, type AppleRejection } from './_scan_intelligence.js';
+import { IntelligenceAccumulator, emitIntelligence, extractComposerCandidates, splitPerformerCreditString, type CollaborationSignal, type AppleRejection } from './_scan_intelligence.js';
 import { runHealthProbe } from './scan-health.js';
 import { alertSlack } from './_alert.js';
 
@@ -143,13 +143,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   console.log(`[DAILY] universe=${artistNames.length} (seeds=${SEED_ARTISTS.length})`);
 
   const intel = new IntelligenceAccumulator();
-  function splitCredits(s: string): string[] {
-    if (!s) return [];
-    return s.split(/,|\bfeat\.?\b|\bft\.?\b|\bwith\b|\bx\b|\band\b|&/gi).map(n => n.trim()).filter(Boolean);
-  }
   function recordFromTrack(t: any) {
-    const performers = splitCredits(t.artist_names || '');
-    const composers = splitCredits(t.composer_name || '');
+    const performers = splitPerformerCreditString(t.artist_names || '');
+    const composers = splitPerformerCreditString(t.composer_name || '');
     const seen = new Set<string>();
     const participants: CollaborationSignal['participants'] = [];
     for (const p of performers) {

--- a/api/cron-scan-weekly.ts
+++ b/api/cron-scan-weekly.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
-import { IntelligenceAccumulator, emitIntelligence, type CollaborationSignal, type AppleRejection } from './_scan_intelligence.js';
+import { IntelligenceAccumulator, emitIntelligence, extractComposerCandidates, type CollaborationSignal, type AppleRejection } from './_scan_intelligence.js';
 import { runHealthProbe } from './scan-health.js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
@@ -335,7 +335,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const tracks = data.tracks || [];
         appleTracks += tracks.length;
         // R13: extract collaboration + velocity signals from every track
-        for (const t of tracks) recordCollaborationFromTrack(t, 'apple');
+        for (const t of tracks) {
+          recordCollaborationFromTrack(t, 'apple');
+          // M-Z13: raw Apple composerName signal for Alpha's M20 credit ingest
+          const composers = extractComposerCandidates(t.composer_name);
+          if (composers.length > 0) {
+            intel.recordAppleComposerCredit({
+              track_id: t.track_id,
+              track_name: t.track_name,
+              primary_artist_id: t.artist_id || null,
+              primary_artist_name: t.artist_names || '',
+              composer_names: composers,
+              source: 'apple_composer_field',
+              release_date: t.release_date || null,
+            });
+          }
+        }
         // R12: record any ISRC-verify rejections so Thread A can act on them
         // (wrong-person Apple matches gated before cache write).
         const rejections = (data.apple_rejections || []) as AppleRejection[];

--- a/api/cron-scan-weekly.ts
+++ b/api/cron-scan-weekly.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
-import { IntelligenceAccumulator, emitIntelligence, extractComposerCandidates, type CollaborationSignal, type AppleRejection } from './_scan_intelligence.js';
+import { IntelligenceAccumulator, emitIntelligence, extractComposerCandidates, splitPerformerCreditString, type CollaborationSignal, type AppleRejection } from './_scan_intelligence.js';
 import { runHealthProbe } from './scan-health.js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
@@ -157,21 +157,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // credit contributes to collaboration signals. Emitted at end of chain.
   const intel = new IntelligenceAccumulator();
 
-  /** Split a comma / feat / ft / & / x — separated credit string into names. */
-  function splitCreditString(s: string): string[] {
-    if (!s) return [];
-    return s
-      .split(/,|\bfeat\.?\b|\bft\.?\b|\bwith\b|\bx\b|\band\b|&/gi)
-      .map(n => n.trim())
-      .filter(n => n.length > 0);
-  }
+  /** Shared splitter — see `splitPerformerCreditString` in _scan_intelligence.ts.
+   *  Inline helper removed (had `\bfeat\.?\b` boundary bug — same class as the
+   *  M-Z13 composer-credits test). */
 
   /** Extract collaboration signals from one track and record to accumulator.
    *  A signal fires when 2+ distinct names from the credit strings
    *  (performers + Apple composerName) are in the Nashville universe. */
   function recordCollaborationFromTrack(t: any, source: 'apple' | 'spotify') {
-    const performers = splitCreditString(t.artist_names || '');
-    const composers = splitCreditString(t.composer_name || '');
+    const performers = splitPerformerCreditString(t.artist_names || '');
+    const composers = splitPerformerCreditString(t.composer_name || '');
     const seen = new Set<string>();
     const participants: CollaborationSignal['participants'] = [];
     for (const p of performers) {

--- a/tests/unit/composer-credits.test.ts
+++ b/tests/unit/composer-credits.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { extractComposerCandidates, IntelligenceAccumulator } from '../../api/_scan_intelligence';
+
+describe('extractComposerCandidates (M-Z13)', () => {
+  it('returns empty array for null/undefined/empty', () => {
+    expect(extractComposerCandidates(null)).toEqual([]);
+    expect(extractComposerCandidates(undefined)).toEqual([]);
+    expect(extractComposerCandidates('')).toEqual([]);
+  });
+
+  it('splits a single-composer string', () => {
+    expect(extractComposerCandidates('Ashley Gorley')).toEqual(['Ashley Gorley']);
+  });
+
+  it('splits comma-separated composers', () => {
+    expect(extractComposerCandidates('Ashley Gorley, Hillary Lindsey, Shane McAnally'))
+      .toEqual(['Ashley Gorley', 'Hillary Lindsey', 'Shane McAnally']);
+  });
+
+  it('splits on ampersand', () => {
+    expect(extractComposerCandidates('Sarah Buxton & Natalie Hemby'))
+      .toEqual(['Sarah Buxton', 'Natalie Hemby']);
+  });
+
+  it('splits on feat/ft', () => {
+    expect(extractComposerCandidates('Morgan Wallen feat. HARDY')).toEqual(['Morgan Wallen', 'HARDY']);
+    expect(extractComposerCandidates('Morgan Wallen ft. HARDY')).toEqual(['Morgan Wallen', 'HARDY']);
+  });
+
+  it('handles mixed separators', () => {
+    expect(extractComposerCandidates('A, B & C, D'))
+      .toEqual(['A', 'B', 'C', 'D']);
+  });
+
+  it('trims whitespace', () => {
+    expect(extractComposerCandidates('   Ashley Gorley   ,   Shane McAnally   '))
+      .toEqual(['Ashley Gorley', 'Shane McAnally']);
+  });
+
+  it('filters empty fragments', () => {
+    expect(extractComposerCandidates('Ashley,,,Shane')).toEqual(['Ashley', 'Shane']);
+  });
+
+  it('rejects fragments > 120 chars (likely parse error)', () => {
+    const longName = 'A'.repeat(130);
+    expect(extractComposerCandidates(longName)).toEqual([]);
+    expect(extractComposerCandidates(`Real Name, ${longName}`)).toEqual(['Real Name']);
+  });
+
+  it('preserves hyphenated single names (does not split on hyphen)', () => {
+    expect(extractComposerCandidates('Jean-Baptiste Lully')).toEqual(['Jean-Baptiste Lully']);
+  });
+});
+
+describe('IntelligenceAccumulator.recordAppleComposerCredit (M-Z13)', () => {
+  it('accumulates credits and includes them in build() output', () => {
+    const intel = new IntelligenceAccumulator();
+    intel.recordAppleComposerCredit({
+      track_id: 'apple_isrc_USABC1234567',
+      track_name: 'Example Song',
+      primary_artist_id: '907166363',
+      primary_artist_name: 'Lainey Wilson',
+      composer_names: ['Ashley Gorley', 'Hillary Lindsey'],
+      source: 'apple_composer_field',
+      release_date: '2026-04-19',
+    });
+    intel.recordAppleComposerCredit({
+      track_id: 'apple_isrc_USXYZ9876543',
+      track_name: 'Another Song',
+      primary_artist_id: '2715720',
+      primary_artist_name: 'Miranda Lambert',
+      composer_names: ['Natalie Hemby'],
+      source: 'apple_composer_field',
+      release_date: '2026-04-18',
+    });
+    const artifact = intel.build({
+      scan_week: '2026-04-19',
+      scanner: 'nmf_weekly_cron',
+      scope: { universe_source: 'seed', artists_input: 2, artists_with_releases: 2, tracks_found: 2 },
+    });
+    expect(artifact.composer_credits).toHaveLength(2);
+    expect(artifact.composer_credits[0].composer_names).toEqual(['Ashley Gorley', 'Hillary Lindsey']);
+    expect(artifact.composer_credits[1].primary_artist_name).toBe('Miranda Lambert');
+  });
+
+  it('build() emits empty composer_credits array when none recorded', () => {
+    const intel = new IntelligenceAccumulator();
+    const artifact = intel.build({
+      scan_week: '2026-04-19',
+      scanner: 'nmf_weekly_cron',
+      scope: { universe_source: 'seed', artists_input: 0, artists_with_releases: 0, tracks_found: 0 },
+    });
+    expect(artifact.composer_credits).toEqual([]);
+  });
+});

--- a/tests/unit/split-performer-credit-string.test.ts
+++ b/tests/unit/split-performer-credit-string.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { splitPerformerCreditString } from '../../api/_scan_intelligence';
+
+// M-Z-W3-2: regression tests against the `\bfeat\.?\b` trailing-boundary bug
+// that tripped the M-Z13 composer-credits test. Same lookahead-on-right fix
+// as `extractComposerCandidates` but with the wider delimiter set (with, x,
+// and) used for performer credits in cron-scan-weekly + cron-scan-daily.
+
+describe('splitPerformerCreditString (M-Z-W3-2)', () => {
+  it('returns empty array for null/undefined/empty', () => {
+    expect(splitPerformerCreditString(null)).toEqual([]);
+    expect(splitPerformerCreditString(undefined)).toEqual([]);
+    expect(splitPerformerCreditString('')).toEqual([]);
+  });
+
+  it('returns single name when no delimiter present', () => {
+    expect(splitPerformerCreditString('Morgan Wallen')).toEqual(['Morgan Wallen']);
+  });
+
+  it('splits on comma', () => {
+    expect(splitPerformerCreditString('Luke Combs, Chris Stapleton'))
+      .toEqual(['Luke Combs', 'Chris Stapleton']);
+  });
+
+  it('splits on ampersand', () => {
+    expect(splitPerformerCreditString('Jelly Roll & Lainey Wilson'))
+      .toEqual(['Jelly Roll', 'Lainey Wilson']);
+  });
+
+  // THE BUG — previous regex `\bfeat\.?\b` failed because `.` then space is
+  // non-word → non-word (no word boundary). The new lookahead `(?=\s|$|,|&)`
+  // matches after the optional dot regardless of whether the `.` is followed
+  // by a word-boundary-inducing character.
+  it('splits `feat.` with trailing space (regression for \\bfeat\\.?\\b bug)', () => {
+    expect(splitPerformerCreditString('Morgan Wallen feat. HARDY'))
+      .toEqual(['Morgan Wallen', 'HARDY']);
+  });
+
+  it('splits `ft.` with trailing space', () => {
+    expect(splitPerformerCreditString('Post Malone ft. Morgan Wallen'))
+      .toEqual(['Post Malone', 'Morgan Wallen']);
+  });
+
+  it('splits `feat.` followed by comma', () => {
+    expect(splitPerformerCreditString('Zach Bryan feat. Kacey Musgraves, Sierra Ferrell'))
+      .toEqual(['Zach Bryan', 'Kacey Musgraves', 'Sierra Ferrell']);
+  });
+
+  it('splits on `with`', () => {
+    expect(splitPerformerCreditString('Jason Aldean with Carrie Underwood'))
+      .toEqual(['Jason Aldean', 'Carrie Underwood']);
+  });
+
+  it('splits on `x`', () => {
+    expect(splitPerformerCreditString('Bailey Zimmerman x Jelly Roll'))
+      .toEqual(['Bailey Zimmerman', 'Jelly Roll']);
+  });
+
+  it('splits on `and`', () => {
+    expect(splitPerformerCreditString('Brothers Osborne and Dierks Bentley'))
+      .toEqual(['Brothers Osborne', 'Dierks Bentley']);
+  });
+
+  // IMPORTANT: the lookahead must not swallow `featuring` (the `feat` prefix is
+  // part of a longer word). Treat this as `featuring` the whole artist name.
+  it('does not split on `featuring` (word boundary)', () => {
+    // `featuring` as a substring should NOT be split on the `feat` prefix
+    // because `featuring` has no space after `feat.?` (it continues with `uring`).
+    expect(splitPerformerCreditString('Artist featuring Someone'))
+      .toEqual(['Artist featuring Someone']);
+  });
+
+  it('mixed delimiters chain correctly', () => {
+    expect(splitPerformerCreditString('Ashley McBryde, Carly Pearce & Kelsea Ballerini feat. Lindsay Ell'))
+      .toEqual(['Ashley McBryde', 'Carly Pearce', 'Kelsea Ballerini', 'Lindsay Ell']);
+  });
+
+  it('trims whitespace from split segments', () => {
+    expect(splitPerformerCreditString('  A ,  B  &  C  '))
+      .toEqual(['A', 'B', 'C']);
+  });
+
+  it('filters empty segments', () => {
+    expect(splitPerformerCreditString('A,,B'))
+      .toEqual(['A', 'B']);
+  });
+});


### PR DESCRIPTION
## Summary

Three commits from Zeta W3 sub-wave 1, landed via feature branch + PR per strategy's auth ruling (1720 UTC).

- `a6406b4` — **[Z-W2-M-Z13]** Apple `composerName` extraction as `AppleComposerCredit` signal in `nmf_scan_intelligence` + wired into weekly + daily crons + 12 unit tests. Never landed on origin during W2 close.
- `2d8410e` — **[Z-W3] CI** workflow replacement per strategy's template: build, vitest, contract tests (PRs), Playwright (main), slim scan-health probe (main).
- `6ad54b9` — **[Z-W3-M-Z-W3-2]** `splitPerformerCreditString` extracted into `_scan_intelligence.ts` with `\bfeat\.?(?=\s|\$|,|&)` lookahead fix (same class as the M-Z13 composer-credits bug). Inline copies replaced in `cron-scan-weekly.ts` + `cron-scan-daily.ts`. 14 regression tests added.

## Test plan

- [x] `npx tsc --noEmit` green locally
- [x] `npx vitest run` → 37 files / 470 tests pass (+14 from the new regression file)
- [ ] `ci / vitest` green in this PR
- [ ] Post-merge: Playwright + scan-health probe on main push