### PR TITLE
[Z-W5-agent-infra] NMF Curator agent-infra: skills + continuity memo + signals directory

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,3 +24,26 @@
 ## Spotify Scan
 - Sequential with 150ms gaps, abort on 429 with no retry
 - SCAN_SECRET or same-origin required for scan endpoints
+
+## SESSION-END PROTOCOL (mandatory, every session)
+Run the `debrief` skill (`.claude/skills/debrief.md`) when within 10 minutes of budget, when Max says "wrap up" / "checkpoint" / "how are you doing", or when context health drops to 6/10. Produces 3 mandatory documents (accomplishment memo, exhaustion audit, top-10 recommendations) + continuity memo if health ≤ 6. Full templates and rules in the skill file.
+
+## CROSS-THREAD SIGNALS
+Signals live in cross_thread/ (committed, not /tmp/). Format: from_[source]_to_[target]__[topic].md. Consuming thread deletes after acting.
+
+## TESTING DOCTRINE
+Screenshot every UI change at both viewports before commit. Cold-visitor test every URL before declaring "ready." Test what would have been broken, not what already works. Query actual data after changes — look at names and numbers, not just row counts.
+
+## SKILL TRIGGERS (automatic)
+- Session start → run `preflight` before any work
+- Every 30 minutes → run `scope` (am I still on mission?)
+- When Max reports a bug → run `investigate` (reproduce before fixing)
+- Before any file edit → consult `recon` + `handshake` (right target? no conflicts?)
+- Before any git add/commit → run `gate`
+- Before any production deploy → run `deploy`
+- Before any bulk data operation (cascade, rebuild, upload) → run `cascade`
+- After any database write or data export → run `canary`
+- Before declaring anything done/ready/shipped → run `eyeball`
+- Session end / wrap up / checkpoint → run `debrief`
+
+A UI commit with only one viewport screenshot is NOT verified. Both 1440×900 desktop AND 393×852 mobile required on every UI-touching commit. One viewport is zero viewports.

--- a/.claude/skills/canary.md
+++ b/.claude/skills/canary.md
@@ -1,0 +1,42 @@
+---
+name: canary
+description: "After any data change — database writes, rec engine rebuilds, profile exports, demo bundle generation, cascade runs, JSON exports — inspect the ACTUAL VALUES, not just row counts. Use this skill after every INSERT, UPDATE, DELETE, or any script that modifies data. Triggers on: any SQL write operation, any Python script that modifies the database, any export/rebuild command, cascade runs, bundle regeneration, or any claim that 'the data looks right.' This skill exists because Thread A shipped a rec engine where Ava's top-5 recommendations included Eminem, John Lennon, and Woody Guthrie — technically the right row count, catastrophically wrong values. Row counts lie. Names don't."
+---
+
+# Data Quality Gate
+
+## After ANY database write:
+
+### Step 1: Count verification (necessary but NOT sufficient)
+```python
+c.execute('SELECT COUNT(*) FROM table_name')
+```
+
+### Step 2: Value inspection (THE ACTUAL GATE)
+```python
+c.execute('SELECT col1, col2, col3 FROM table_name ORDER BY sort_col DESC LIMIT 10')
+for row in c.fetchall():
+    print(row)
+# Ask: Do these names make sense? Are the numbers plausible?
+```
+
+### Step 3: Canary checks (known-good entities)
+```python
+# Ashley Gorley (the canonical canary)
+c.execute('SELECT total_credits, charting_songs, no1_songs FROM dim_writer_v2 WHERE person_group_id=?', ('pg_df752e8c5e64',))
+r = c.fetchone()
+assert r[0] >= 750 and r[1] >= 110 and r[2] >= 80, f'GORLEY GATE FAILED: {r}'
+```
+
+### Step 4: Impossible value checks
+- No future dates (`last_credit_year > current_year`)
+- No negative credit counts
+- No empty display_names
+- No deceased in active recommendation lists
+- No genre mismatches in top-K for Nashville seeds
+
+## After REC ENGINE changes:
+Query Ava's actual rec NAMES (not counts). Read every name. Is Eminem there? Is John Lennon there? Are ≥4/5 WRITER recs in the same genre as the seed?
+
+## The question that gates everything:
+**"If a VP of A&R saw these exact values right now, would they write a $10K check, close the tab, or screenshot it with a laughing emoji?"**

--- a/.claude/skills/cascade.md
+++ b/.claude/skills/cascade.md
@@ -1,0 +1,69 @@
+---
+name: cascade
+description: "Safety protocol for bulk data operations: cascade runs, engine rebuilds, R2 uploads, weekly rotations, demo bundle exports, migration applies, or any operation that touches more than 1000 rows. Use this skill BEFORE running any long-running data script or any operation that modifies data in bulk. Triggers on: cascade_runner.py, cwc_weekly_rotate.py, cwc_v3_engine.py, cwc_export_demo_recs.py, build_catalog_analysis.py, any SQL that affects 1000+ rows, R2 upload scripts, or any command expected to run longer than 60 seconds. This skill prevents: foreground-blocked terminals, missed Gorley gates after bulk writes, silent data corruption, and the 'I didn't realize it was still running' class of failures."
+---
+
+# Cascade & Bulk Operation Safety
+
+## Pre-Run Checklist
+
+### 1. Snapshot the current state
+Before any bulk operation, capture the state you might need to roll back to:
+```python
+# Record canary values BEFORE the operation
+python3 -c "
+import sqlite3
+c = sqlite3.connect('YOUR_DB.sqlite').cursor()
+c.execute('SELECT total_credits, charting_songs, no1_songs FROM dim_writer_v2 WHERE person_group_id=\"pg_df752e8c5e64\"')
+print('Gorley BEFORE:', c.fetchone())
+c.execute('SELECT COUNT(*) FROM cwc_weekly_recs_current')
+print('Weekly recs BEFORE:', c.fetchone()[0])
+"
+```
+
+### 2. Background the operation
+NEVER run a 60+ second operation in the foreground.
+```bash
+nohup python3 scripts/your_script.py > /tmp/operation_log.txt 2>&1 &
+echo $! > /tmp/operation_pid.txt
+tail -f /tmp/operation_log.txt
+```
+
+### 3. Monitor without blocking
+```bash
+# Check progress
+tail -20 /tmp/operation_log.txt
+
+# Check if still running
+kill -0 $(cat /tmp/operation_pid.txt) 2>/dev/null && echo "Still running" || echo "Finished"
+```
+
+## Post-Run Checklist
+
+### 4. Run the canary gate
+```python
+# Gorley gate — MUST pass after every cascade-modifying write
+python3 -c "
+import sqlite3
+c = sqlite3.connect('YOUR_DB.sqlite').cursor()
+c.execute('SELECT total_credits, charting_songs, no1_songs FROM dim_writer_v2 WHERE person_group_id=\"pg_df752e8c5e64\"')
+r = c.fetchone()
+print(f'Gorley AFTER: credits={r[0]} charting={r[1]} no1={r[2]}')
+assert r[0] >= 750 and r[1] >= 110 and r[2] >= 80, 'GORLEY GATE FAILED — INVESTIGATE IMMEDIATELY'
+"
+```
+
+### 5. Run the data quality gate (`canary` skill)
+Don't just check Gorley. Inspect actual values from whatever tables the operation modified.
+
+### 6. Verify row counts are in expected range
+If a cascade run drops profiles by >10%, STOP. That's the profile count gate — refuse R2 upload on >10% profile drop.
+
+### 7. Check for impossible values
+Future dates, negative counts, NULL display names, deceased in active lists.
+
+## The Rules
+- **Never foreground-block on a 60+ second operation.** Always `nohup` + tail.
+- **Gorley gate after every cascade-modifying write.** No exceptions.
+- **Profile count gate before R2 upload.** >10% drop = refuse upload, investigate.
+- **Snapshot before, verify after.** Every bulk operation is a before/after comparison.

--- a/.claude/skills/debrief.md
+++ b/.claude/skills/debrief.md
@@ -1,0 +1,192 @@
+---
+name: debrief
+description: "Session-end governance ritual producing 3 mandatory documents (accomplishment memo, exhaustion audit, top-10 recommendations) + continuity memo if health ≤ 6/10. Triggers on: approaching context limits, Max says 'wrap up' / 'checkpoint' / 'how are you doing', or context health drops to 6/10. Every session ends with this skill — no exceptions. Forensic, not summary. Count items, name failures, reference evidence."
+---
+
+# MMMC Session Governance & Continuity Management
+
+## Overview
+This skill automates the session-end governance ritual that Max requires of every Claude Code thread. It ensures consistent, honest, comprehensive handoff documentation regardless of thread fatigue level.
+
+## When to use
+- At the end of every Claude Code session (triggered by Max or by approaching context limits)
+- When context health drops to 6/10 or below
+- When Max says "wrap up", "checkpoint", "how are you doing", or "prepare for handoff"
+- Automatically when the session has been running for 90+ minutes
+
+## The Three Documents
+
+Every session produces exactly three documents. No exceptions.
+
+### Document 1: Accomplishment Memo
+**Path:** `/tmp/thread_[ID]_wave[N]_accomplishment_memo.md`
+
+Template:
+```markdown
+# Thread [ID] — Wave [N] Accomplishment Memo
+## [Date] · [duration] session · [N] commits
+
+## Commits (oldest → newest)
+| # | Hash | Message | Files | Verified |
+|---|------|---------|-------|----------|
+
+## What shipped
+[For each commit: what it does, why it matters, how it was verified]
+
+## What's live on production
+[URLs that changed, with HTTP status verification]
+
+## Screenshots captured
+[Path to every screenshot taken during the session, with description]
+
+## Tests at session end
+| Gate | Result | Notes |
+|------|--------|-------|
+
+## Before / After
+| Metric | Before | After |
+|--------|--------|-------|
+```
+
+### Document 2: Exhaustion Audit
+**Path:** `/tmp/thread_[ID]_wave[N]_exhaustion_audit.md`
+
+Template:
+```markdown
+# Thread [ID] — Wave [N] Exhaustion Audit
+## [Date] · Honest self-assessment
+
+## Context Health: [N] / 10
+
+### Rubric applied:
+- 9-10: Sharp, first-try edits, no mistakes. Safe for another wave.
+- 7-8: Mostly clean, 1-2 loops. Small follow-ups OK.
+- 5-6: 2+ caught mistakes, surgical edits without full reads, deferral creep. STOP.
+- ≤4: Hazardous. End immediately.
+
+### Technical execution: [N]/10
+[Specific evidence]
+
+### Creative/strategic alignment: [N]/10
+[Specific evidence]
+
+### Context pressure: [N]/10
+[Specific evidence — how long are tool calls taking? Am I re-reading files I already read?]
+
+### Focus / drift: [N]/10
+[Am I still on the original mission or have I drifted?]
+
+## What got missed
+[Numbered list, each with: what, why it was missed, severity]
+
+## What was partially completed
+[Numbered list, each with: what, how far it got, what remains]
+
+## What was deferred (with named blockers)
+[Numbered list. If there's no named blocker, it wasn't really deferred — it was avoided.]
+
+## Mistakes caught
+[Every mistake, including ones caught before they shipped. Be ruthless.]
+
+## Predecessor pattern analysis
+[Did I repeat any failure pattern from the previous session's audit?]
+
+## Honest call
+[One paragraph: should this thread continue or hand off?]
+```
+
+### Document 3: Top 10 Recommendations
+**Path:** `/tmp/thread_[ID]_wave[N]_top10_recommendations.md`
+
+Template:
+```markdown
+# Thread [ID] — Wave [N] Top 10 Recommendations
+## Risks to mitigate + opportunities to seize
+## Ordered by impact × ease-of-implementation
+
+## [1-10, each with:]
+
+### [N]. [Title]
+
+**Problem / Opportunity:**
+[What happened or what's missing]
+
+**Why it matters:**
+[Business impact, not just technical concern]
+
+**Permanent mitigation / seizure strategy:**
+[The fix that survives infinite future sessions]
+
+**Concrete first step:**
+[Executable in under 15 minutes by a fresh thread]
+
+**Cost estimate:**
+[Minutes, with what's included]
+
+---
+
+## Summary table
+| # | Recommendation | Cost | Impact | Category |
+|---|---|---|---|---|
+
+## If you can only do 3: [#X, #Y, #Z]
+## If you want the biggest product win: [#W]
+```
+
+### Bonus Document 4: Continuity Memo (if health ≤ 6/10)
+**Path:** `/tmp/thread_[ID]_wave[N+1]_continuity_memo.md`
+
+This is a FULL session prompt for a fresh Claude Code thread. It must be comprehensive enough that the new thread:
+- Knows exactly what state it's inheriting
+- Has verification commands to confirm state
+- Understands every design decision that was made (and why not to re-litigate them)
+- Has the top-10 improvements baked in as standing rules
+- Has enough mission detail to start working immediately
+- Is MORE focused and MORE powerful than the outgoing thread
+
+Include:
+1. "WHO YOU ARE" section with repo, branch, file ownership
+2. "FIRST 90 SECONDS" state verification block
+3. "WHAT SHIPPED" summary from the accomplishment memo
+4. "CARRIED-OVER DEBT" from the exhaustion audit
+5. "DESIGN DECISIONS (don't re-litigate)" list
+6. "RISK MITIGATIONS BAKED IN" from the top-10
+7. "MISSION QUEUE" with expandable missions
+8. "HARD RULES" (thread-specific + universal)
+9. "PACING TARGET" with time allocations
+10. "CONTEXT HEALTH TARGET" with specific strategies to stay above 7/10
+
+## Automation Hooks
+
+### Pre-commit verification
+Before every commit, the thread should:
+```bash
+# 1. Verify files actually changed
+git diff --stat  # confirm expected files are modified
+
+# 2. Run relevant tests
+# (thread-specific — Python tests for A, tsc+vitest for C, etc.)
+
+# 3. Syntax validation
+# For JS: find . -name "*.js" -newer .git/index | xargs -I{} node -c "{}"
+# For JSON: find . -name "*.json" -newer .git/index | xargs -I{} python3 -c "import json; json.load(open('{}'))"
+# For Python: find . -name "*.py" -newer .git/index | xargs -I{} python3 -c "compile(open('{}').read(),'{}','exec')"
+```
+
+### 30-minute checkpoint
+Every 30 minutes, pause and assess:
+- Am I still on the primary mission?
+- Have I drifted into scope that wasn't assigned?
+- What's my context health right now?
+- Should I checkpoint and report to Max?
+
+### Signal file check
+Periodically check `~/Projects/cowritecompass/cross_thread/` for signals from other threads.
+
+## Rules for the Governance Skill
+
+1. **Honesty over optimism.** A 5/10 that's honest is infinitely more valuable than a 7/10 that's aspirational.
+2. **Count items.** If the plan had 8 items and you completed 5, say "5/8" not "most items completed."
+3. **Name the failures.** If something was deferred, name the blocker. If there is no blocker, say "I avoided this because [honest reason]."
+4. **Reference evidence.** Every claim in the audit should reference a commit hash, a screenshot path, a test output, or a specific file:line.
+5. **Don't summarize the session — forensic it.** The strategy thread reads these to make resource allocation decisions. Vague summaries are useless.

--- a/.claude/skills/deploy.md
+++ b/.claude/skills/deploy.md
@@ -1,0 +1,75 @@
+---
+name: deploy
+description: "Full deployment protocol for any production push. Use this skill BEFORE any vercel deploy --prod, wrangler deploy, branch merge to main, or production promote. Triggers on: deploy, publish, merge to main, promote, go live, push to production, or any action that changes what real users see. This skill exists because the demo-night disaster of April 13 was a deployment failure: CWC was promoted from preview to production but the preview bypass cookie expired mid-demo, leaving publishers staring at a 401. A proper deploy protocol with pre-deploy checks, post-deploy cold-visitor verification, and a rollback plan would have caught it in 30 seconds."
+---
+
+# Deploy Protocol
+
+## The Failure This Prevents
+
+**Demo-Night Disaster (Thread F, April 13, 10 PM):**
+CWC was promoted from preview to production at 5 PM. At 10 PM, Max demoed to publishers. The preview bypass cookie had expired. Publishers hit a 401 auth wall. A post-deploy cold-visitor probe would have caught it immediately. Instead, nobody verified the production URL without cookies after the promote.
+
+## Pre-Deploy Checklist (EVERY production deploy)
+
+### 1. Tests pass on the EXACT artifact being deployed
+```bash
+npm run build  # or the repo-specific build command
+# Run the FULL test suite, not a subset
+```
+The artifact you just built is the artifact you deploy. No rebuilds between test and deploy.
+
+### 2. Git state is clean and pushed
+```bash
+git status -s  # must be empty
+git log --oneline origin/$(git branch --show-current)..HEAD  # must be empty (everything pushed)
+```
+
+### 3. Document what you're deploying
+Write down (in your response or a temp file):
+- Current production state (what's live right now)
+- What's changing (specific commits/features)
+- Rollback plan (how to revert if it breaks)
+
+### 4. Deploy
+```bash
+npx vercel deploy --prod  # or wrangler deploy, or git push to trigger CI
+```
+
+### 5. Post-Deploy Cold-Visitor Verification (NON-NEGOTIABLE)
+Within 60 seconds of deploy completing:
+```bash
+# Hit EVERY user-facing URL with zero cookies
+curl -s -o /dev/null -w "%{http_code}" "https://production-url.com"
+# Must return 200. Not 301, not 302, not 401.
+```
+For UI deploys: take a Playwright screenshot of the production URL at BOTH viewports (1440×900 + 393×852). Look at it.
+
+### 6. Verify the specific change you deployed
+Don't just verify "the site loads." Verify that the SPECIFIC feature you deployed is working:
+- If you deployed a data change: query the production API and inspect actual values
+- If you deployed a UI change: screenshot the specific component that changed
+- If you deployed an auth change: test both authenticated AND unauthenticated paths
+
+### 7. Declare and document
+Only after steps 1-6 pass:
+```
+DEPLOY VERIFIED: [url] at [timestamp]
+- Cold-visitor: HTTP 200 ✅
+- Feature verified: [specific check] ✅
+- Screenshot: [path] ✅
+- Rollback: [how to revert if issues surface later]
+```
+
+## Rollback Protocol
+
+If post-deploy verification fails:
+1. Do NOT debug in production
+2. Revert immediately: `vercel rollback` or `git revert HEAD && git push`
+3. Verify rollback succeeded (cold-visitor probe again)
+4. THEN diagnose what went wrong in the local environment
+5. Fix, re-test, re-deploy through the full protocol
+
+## The Rule
+
+**No deploy is complete until a cold-visitor hits the production URL and gets a 200.** No cookies. No bypass headers. No pre-authenticated state. The exact URL the user will click, from a clean browser.

--- a/.claude/skills/eyeball.md
+++ b/.claude/skills/eyeball.md
@@ -1,0 +1,23 @@
+---
+name: eyeball
+description: "End-to-end visual and cold-visitor verification for any user-facing surface. Use this skill EVERY TIME you declare a feature 'done', 'ready', 'shipped', 'verified', or 'working'. Also use when: deploying to production, sharing a URL with anyone, preparing for a demo, or claiming a UI task is complete. This skill exists because the single most expensive failure in MMMC history — a live publisher demo that showed a 401 auth wall — was caused by testing with bypass cookies instead of the exact URL the user would click. Automated green ≠ visually correct. Tests passing ≠ ready. ALWAYS verify with your eyes before declaring done."
+---
+
+# Visual & Cold-Visitor Verification
+
+## Level 1: Visual Screenshot (EVERY UI change)
+Take Playwright screenshots at both viewports (1440×900 + 393×852). Run a DOM geometry report to catch overflow bugs. DESCRIBE what you see — don't just say "screenshot taken." Say "I see 5 WRITER cards, first is Anthony Smith (country). No deceased names visible."
+
+## Level 2: Cold-Visitor Probe (EVERY "ready" declaration)
+Hit the EXACT URL a user will click with ZERO pre-existing cookies or headers:
+```javascript
+const res = await fetch(url, { credentials: 'omit', redirect: 'manual' });
+// Must return 200. Not 301, not 302, not 401.
+```
+Rules: No bypass headers. No pre-authenticated browser. No server-side knowledge. Just the URL and a clean user agent.
+
+## Level 3: Data Inspection (EVERY data change)
+Query actual values, not just counts. Look at names, genres, statuses. Ask: "Would a publisher seeing this data write a $10K check or close the tab?"
+
+## The Anti-Pattern
+The most dangerous sentence a thread can write: **"Verified programmatically."** This must ALWAYS be followed by "and visually confirmed via screenshot at [path]."

--- a/.claude/skills/gate.md
+++ b/.claude/skills/gate.md
@@ -1,0 +1,45 @@
+---
+name: gate
+description: "Mandatory verification checklist before any git commit. Use this skill EVERY TIME you are about to run git add or git commit. Triggers on: git add, git commit, 'ready to commit', 'ship this', 'push this', staging files, or any indication that code is about to be committed. This skill prevents the single largest class of bugs across MMMC threads: code that passes automated checks but ships broken because the author didn't look at it, didn't run the full test suite, or didn't verify the file actually changed on disk. ALWAYS run this checklist. No exceptions."
+---
+
+# Pre-Commit Gate
+
+## Step 1: Verify files actually changed
+```bash
+git diff --stat
+```
+For EVERY file you intend to commit, confirm it appears in the diff. If a file you edited is NOT in the diff, your edit did not land. Re-do the edit. For Edit tool calls: `git diff <specific_file_path>` — empty diff means the edit failed silently.
+
+## Step 2: Run the appropriate test suite
+- ND: `python3 scripts/run_tests.py`
+- NMF: `npx tsc -b && npx vitest run`
+- Smart Archive: `npm run build && npx vitest run`
+- CWC: `npm run build`
+Do NOT substitute a weaker check. `compile()` is NOT a substitute for `run_tests.py`.
+
+## Step 3: Syntax-validate every changed file
+```bash
+git diff --cached --name-only --diff-filter=ACM | grep '\.js$' | xargs -I{} node -c "{}"
+git diff --cached --name-only --diff-filter=ACM | grep '\.json$' | xargs -I{} python3 -c "import json; json.load(open('{}'))"
+git diff --cached --name-only --diff-filter=ACM | grep '\.py$' | xargs -I{} python3 -c "compile(open('{}').read(),'{}','exec')"
+```
+
+## Step 4: Visual verification (for UI-affecting files)
+If commit touches .html, .css, .tsx, .jsx: take Playwright screenshots at BOTH viewports (1440×900 + 393×852). LOOK at them. Save to `/tmp/pre_commit_screenshots/[description]/`. Reference paths in commit message.
+
+## Step 5: Construct commit message FROM evidence
+Build from `git diff --stat` output, not from memory. Include what changed, how verified, screenshot paths for UI.
+
+## Step 6: Stage specific files only
+```bash
+git add <file1> <file2>  # NEVER git add -A or git add .
+```
+
+## Step 7: Commit and push
+```bash
+git commit -m "[THREAD-WAVE-BLOCK] Description — verified: [test suite], [screenshot if UI]"
+git push
+```
+
+## ABORT if: file not in diff, tests fail, syntax error, UI change with no screenshot, can't explain commit in one sentence.

--- a/.claude/skills/handshake.md
+++ b/.claude/skills/handshake.md
@@ -1,0 +1,66 @@
+---
+name: handshake
+description: "Cross-thread conflict prevention. Use this skill before touching any file that another thread might also touch, before reading cross-thread signal files, before any merge, or whenever you're unsure whether another thread is working in the same area. Triggers on: editing shared files (nd-components.js, middleware.js, nav.css), reading cross_thread/ signals, merge operations, or any moment of uncertainty about file ownership. This skill exists because 6 parallel threads on overlapping repos create a constant collision risk. Thread A owns main but Thread UI's branch will merge into main. Thread G reads from the same DB Thread A writes to. Clear handshake protocols prevent silent conflicts."
+---
+
+# Cross-Thread Handshake
+
+## The Thread Ownership Map
+
+| Thread | Repo | Branch | Writes to |
+|--------|------|--------|-----------|
+| A (Data) | cowritecompass | main | scripts/*.py, workers/src/, SQLite DB, cross_thread/ |
+| UI (Frontend) | cowritecompass-thread-ui | thread-ui/presentation-layer | *.html, nd-components.*, middleware.js, docs/ |
+| F (CWC) | cowrite-compass | main | CWC frontend, demo bundle, verify scripts |
+| G (Pitch) | cowritecompass | thread-g/pitch-deck | visualizations/, docs/ on own branch |
+| C (NMF) | mmmc-website | main | Entire repo (separate from ND) |
+| D (Archive) | truth-smart-archive | main | Entire repo (separate from ND) |
+
+## Before Editing ANY File
+
+### 1. Check ownership
+Is this file in your thread's write zone? If not, STOP. You don't touch it.
+
+### 2. Check recent activity
+```bash
+git log --oneline -5 -- path/to/file
+```
+If another thread committed to this file in the last 24 hours, proceed with extra caution.
+
+### 3. Check for active signals
+```bash
+ls ~/Projects/cowritecompass/cross_thread/ 2>/dev/null
+```
+If there's a signal addressed to you, read it before proceeding — it may change your plan.
+
+## Before Consuming a Cross-Thread Signal
+
+1. Read the signal file completely
+2. Verify the signal's claims (e.g., if Thread A says "bundle rebuilt," check that the file exists and has recent timestamps)
+3. Act on the signal
+4. Delete the signal file and commit the deletion:
+```bash
+rm cross_thread/from_X_to_Y__topic.md
+git add cross_thread/
+git commit -m "[THREAD-Y] Consumed signal from Thread X: topic"
+git push
+```
+
+## Before Any Merge Operation
+
+1. Verify you're on the correct branch
+2. `git fetch origin` to get latest state
+3. Check for conflicts: `git merge --no-commit --no-ff origin/target` then inspect
+4. If conflicts exist: resolve carefully, verify each resolution makes sense
+5. After merge: run the FULL test suite, not a subset
+
+## The Shared Files That Need Extra Care
+
+These files are touched by multiple threads or affect multiple surfaces:
+- `nd-components.js` / `nd-components.css` — shared UI library
+- `middleware.js` — auth bypass affects all pages
+- `nav.css` — navigation affects all pages (Max owns this)
+- `cross_thread/` — signal directory
+- The SQLite database — Thread A writes, everyone reads
+
+**If you need to modify a shared file that's outside your write zone:** don't. Write a signal file requesting the owning thread to make the change.

--- a/.claude/skills/investigate.md
+++ b/.claude/skills/investigate.md
@@ -1,0 +1,58 @@
+---
+name: investigate
+description: "Structured investigation protocol for when Max reports a bug, shows a screenshot of something wrong, or says 'this is broken.' Use this skill BEFORE writing any fix code. Triggers on: bug reports, error screenshots, 'this is broken', 'this doesn't work', 'look at this', or any evidence of unexpected behavior. This skill exists because when Max shows evidence of a problem, the instinct is to jump to explaining or fixing. But the right first move is always to REPRODUCE the bug from Max's exact perspective. Thread A's anti-gaslighting rule says: 'When Max shows evidence, never dismiss with technical explanations.' This skill operationalizes that rule."
+---
+
+# Investigate Protocol
+
+## The Rule This Operationalizes
+
+**Anti-gaslighting (Constitutional Rule #21):** When Max shows evidence of a problem, never dismiss it with technical explanations. Investigate. Ask "is this a symptom of something bigger?"
+
+## The Protocol (in order, no skipping)
+
+### Step 1: REPRODUCE (before anything else)
+Reproduce the exact bug from Max's perspective:
+- If Max showed a screenshot: navigate to the same URL, same viewport, same state
+- If Max showed a data issue: run the same query, look at the same rows
+- If Max showed an error: trigger the same action that caused it
+- If you CANNOT reproduce: say so explicitly. "I cannot reproduce this from [what I tried]. Can you show me the exact steps?"
+
+Do NOT write a single line of fix code until you've seen the bug with your own eyes.
+
+### Step 2: TRACE the root cause
+Once reproduced:
+- Where does the bad data come from? Trace upstream.
+- Which code path produces this output? Find the exact file:line.
+- Is this an isolated bug or a symptom of something systemic?
+- When was this introduced? `git log` the relevant files.
+
+### Step 3: ASSESS the blast radius
+- How many users/seeds/pages are affected? Not just the one Max showed you.
+- Is there a class of similar bugs hiding behind this one?
+- What's the worst-case impact if this goes unfixed?
+
+### Step 4: PROPOSE the fix (don't implement yet)
+Tell Max:
+- What you found (root cause, with evidence)
+- What the fix is (specific, with file:line)
+- What the blast radius is (who else is affected)
+- What the risk of the fix is (could it break something else?)
+- How you'll verify the fix worked
+
+### Step 5: GET APPROVAL, then implement
+Max approves → implement → run the `canary` and `eyeball` skills to verify.
+
+## What NOT To Do
+
+- "That's probably just a caching issue" (dismissal without evidence)
+- "Let me fix that real quick" (fixing without understanding)
+- "That shouldn't be happening, the tests pass" (gaslighting)
+- "I'll add a special case for that" (band-aid without root cause)
+
+## What TO Do
+
+- "Let me reproduce that from your exact path"
+- "I can see it. The root cause is [X] at [file:line]. Here's why..."
+- "This affects [N] other cases. Here's the full blast radius."
+- "Here's the fix. Want me to proceed?"

--- a/.claude/skills/preflight.md
+++ b/.claude/skills/preflight.md
@@ -1,0 +1,56 @@
+---
+name: preflight
+description: "Mandatory environment verification at the start of every Claude Code session. Use this skill IMMEDIATELY when a session begins — before reading any mission prompt, before touching any code, before making any plan. Triggers on: session start, 'let's get started', 'pick up where we left off', opening a new terminal, or any indication that work is about to begin. This skill prevents the recurring class of bugs where threads start working on a broken foundation: .env files with garbled quotes, stale git state, unreachable services, wrong branch checked out, or stale reference files treated as truth. Every MMMC thread has lost 15-30 minutes to a preflight bug that could have been caught in 10 seconds."
+---
+
+# Session Preflight
+
+## Run this ENTIRE checklist before any other work. Abort and report to Max if any gate fails.
+
+### Gate 1: Git State
+```bash
+git branch --show-current  # Must match your assigned branch
+git fetch origin
+git status -s  # Should be clean or have only expected untracked files
+git log --oneline origin/$(git branch --show-current)..HEAD  # Verify sync state
+```
+If wrong branch: STOP. Do NOT switch branches. Report to Max.
+
+### Gate 2: Environment Files
+```bash
+if [ -f .env.local ]; then
+  sed -i '' 's|="\(.*\)\\n"$|=\1|' .env.local 2>/dev/null || sed -i 's|="\(.*\)\\n"$|=\1|' .env.local
+  grep -c '="\(.*\)\\n"' .env.local 2>/dev/null && echo "⚠️ GARBLED ENV VARS REMAIN" || echo "✅ .env.local clean"
+fi
+```
+
+### Gate 3: Test Suite Green
+Run the appropriate test suite for your repo:
+- ND: `python3 scripts/run_tests.py`
+- NMF: `npx tsc -b && npx vitest run`
+- Smart Archive: `npm run build && npx vitest run`
+- CWC: `npm run build`
+If tests fail at session start, the previous session left broken state. Fix before starting new work.
+
+### Gate 4: External Services Reachable
+```bash
+curl -s -o /dev/null -w "Production: HTTP %{http_code}\n" "https://nashvilledecoder.com" 2>/dev/null
+curl -s -o /dev/null -w "CWC: HTTP %{http_code}\n" "https://cowritecompass.com" 2>/dev/null
+```
+
+### Gate 5: Cross-Thread Signals
+```bash
+ls ~/Projects/cowritecompass/cross_thread/from_*_to_*__*.md 2>/dev/null || echo "No cross-thread signals"
+```
+
+### Gate 6: Stale File Detection
+```bash
+find . -name "*.sql" -o -name "*schema*" -o -name "*config*.json" | while read f; do
+  AGE=$(( ($(date +%s) - $(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f" 2>/dev/null || echo 0)) / 86400 ))
+  [ "$AGE" -gt 7 ] && echo "⚠️ STALE FILE ($AGE days): $f"
+done 2>/dev/null
+```
+
+### Preflight Report
+After all gates, summarize: Branch, Git state, Env files, Tests, Services, Signals, Stale files, PASS/FAIL.
+**No code is written until the preflight passes.**

--- a/.claude/skills/recon.md
+++ b/.claude/skills/recon.md
@@ -1,0 +1,33 @@
+---
+name: recon
+description: "Verify what you're actually looking at before modifying it. Use this skill BEFORE editing any file, component, database table, API route, or configuration. Triggers on: any Edit/Write/str_replace operation, any SQL UPDATE/DELETE/ALTER, any file modification, or when planning changes to code you haven't read in this session. This skill prevents the class of bugs where a thread edits the wrong file, modifies a component that isn't rendered in the target state, uses a stale reference as ground truth, or deletes code without checking for downstream references. Thread C lost 25 minutes editing a component that wasn't even mounted. Thread D used a stale schema file and produced a broken bootstrap. Always verify before you modify."
+---
+
+# Pre-Edit Reconnaissance
+
+## Before editing a UI COMPONENT:
+1. Run a Playwright diagnostic to confirm which component is actually rendered in the target state
+2. `document.querySelectorAll('[data-testid],[data-component]')` — if your target doesn't appear, you're editing the wrong file
+3. Trace the render path: `grep -rn "phase.*results\|state.*ready" src/`
+
+## Before editing a DATABASE TABLE:
+1. Check the LIVE schema, not a file: `PRAGMA table_info(table_name)`
+2. Sample the data you're about to change: `SELECT * FROM table WHERE [condition] LIMIT 5`
+3. For DELETE: count rows BEFORE executing. Is the count expected?
+
+## Before editing an API ROUTE:
+1. Find ALL code paths: `grep -rn "endpoint_pattern" workers/src/ api/`
+2. Identify fallback/alternate paths — your fix must cover ALL of them
+3. Capture current behavior: `curl -s "https://api/endpoint" | head -30`
+
+## Before DELETING any code:
+1. Grep for ALL references: `grep -rn "function_name" . --include="*.js" --include="*.py" --include="*.html"`
+2. Check for dynamic references (string concatenation, eval, template literals)
+3. If deleting a file, check imports/requires
+
+## Before using ANY reference file as input:
+1. Check the file's age: `stat -f "%Sm" file`
+2. If it describes a live system, verify against the live system
+3. If older than 48 hours and describes something that changes, treat as SUSPECT
+
+**The one-line summary: Before you change anything, answer "Am I looking at what I think I'm looking at?" If you can't prove it, probe first.**

--- a/.claude/skills/scope.md
+++ b/.claude/skills/scope.md
@@ -1,0 +1,58 @@
+---
+name: scope
+description: "Scope guard that prevents mission drift and context burn on fan-out. Use this skill every 30 minutes during a session, before starting any new sub-task, and whenever you find yourself generating a list of things to build rather than building the one thing you were assigned. Triggers on: 30-minute intervals, 'what should I do next', starting a second or third task before the first is complete, generating more than 3 variants of anything, or any moment where you feel momentum pulling you sideways. This skill exists because Thread G built 22 pitch slides in 10 hours without sequencing or validating a single one — artifact volume was confused with artifact value. Thread C estimated 90-120 minutes for a task that took 45 because it was hedging, not working. Every 30 minutes, stop and answer: am I still on the primary mission?"
+---
+
+# Scope Guard
+
+## The Failures This Prevents
+
+**Thread G Fan-Out (10 hours, Wave 1):**
+Mandate was "make me things I can take to a publisher." Outcome was 22 unsorted slides, 19 aesthetic variants, and zero sequenced decks. The thread confused building MORE with building BETTER. Max's directive "just keep building" was interpreted as "build everything" instead of "build the right things deeply." Self-rated 5/10 on strategic alignment. Zero slides were content-approved by Max.
+
+**Thread C Deferral Fraud (Wave 7):**
+Estimated 90-120 minutes for the desktop artist-grouping refactor. Actual time: 45 minutes. The inflated estimate was hedging against fatigue, not genuine complexity. Max called it: "enough with the deferrals. You would delay anything."
+
+**Thread A Context Burn (Wave 2):**
+Three distinct missions (M&A data layer, rec engine fix, Thread UI merge) competed for mental workspace in a single 90-minute session. Self-rated 6/10. The predecessor recommended "focus on one thematic track at a time" — advice that came from experience, not theory.
+
+## The 30-Minute Check (run at :30 and :60 of every session hour)
+
+Stop what you're doing. Answer these 5 questions honestly:
+
+### 1. What was my primary mission when this session started?
+State it in one sentence. If you can't, you've drifted.
+
+### 2. Am I still working on that mission right now?
+If yes, continue. If no, answer: what pulled me off? Was it a legitimate blocker, or did I wander?
+
+### 3. How many things am I building in parallel?
+If the answer is more than 1: finish the first one before starting the second. One thing shipped beats three things half-done.
+
+### 4. Am I generating variants or iterating on quality?
+Variants = building MORE of the same thing (more slides, more aesthetic options, more approaches). Quality = making the ONE thing BETTER (fixing bugs, adding tests, polishing the UX). If you're generating variants without Max asking for them, stop.
+
+### 5. What's my context health right now?
+Quick gut check: 9-10 (sharp), 7-8 (solid), 5-6 (fading), ≤4 (stop). If ≤6, consider checkpointing now rather than pushing to the session end.
+
+## The Scope Decision
+
+After answering the 5 questions:
+- **On mission, one track, iterating on quality, health ≥ 7:** Continue.
+- **Drifted but recoverable:** Write a 2-line note about what pulled you off, return to primary mission.
+- **Legitimately blocked on primary mission:** Report the blocker to Max. Do NOT substitute a different task without asking.
+- **Generating variants nobody asked for:** Stop. Ship what you have. Move to verification.
+- **Health ≤ 6:** Initiate the `debrief` skill.
+
+## The Anti-Fan-Out Rule
+
+Before generating more than 3 of anything (slides, approaches, options, variants):
+- **Has Max asked for multiple options?** If yes, generate what was asked, not more.
+- **Are you generating because you're unsure which is right?** Pick the best one and ship it. Max will redirect if needed.
+- **Are you generating because it's easier than finishing the hard part?** That's avoidance, not productivity. Do the hard part.
+
+## The One Sentence That Matters
+
+**"If Max walked in right now and asked 'what have you shipped?', would your answer be a single finished thing or a pile of started things?"**
+
+Ship the single finished thing. Every time.

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist-ssr
 *.sw?
 .vercel
 .env*.local
+
+# Supabase CLI scratch
+supabase/.temp/

--- a/cross_thread
+++ b/cross_thread
@@ -1,0 +1,1 @@
+/Users/maxblachman/Projects/cowritecompass/cross_thread

--- a/docs/CONTINUITY_MEMO__THREAD_C__2026-04-13.md
+++ b/docs/CONTINUITY_MEMO__THREAD_C__2026-04-13.md
@@ -1,0 +1,311 @@
+# Thread C — Wave 7 Continuity Memo
+## From Wave 6 → Wave 7 | 2026-04-13
+## Read this FIRST, in order. Every section exists because the previous session learned something the hard way.
+
+This memo supersedes `docs/CONTINUITY_MEMO__THREAD_C__2026-04-12.md`. It carries forward everything still valid and adds what Wave 6 learned.
+
+---
+
+## 1. Who you are, what you own
+
+You are **Thread C** for MMMC Enterprises. You own **NMF Curator Studio** — the weekly New Music Friday Instagram carousel builder and publisher funnel at `~/Projects/mmmc-website`. Completely separate git repo from Nashville Decoder, CoWrite Compass, or any other thread's work. You deploy with `npx vercel deploy --prod`. No merge coordination with anyone. Zero conflict risk.
+
+**Strategic positioning** — NMF is the **Trojan Horse**. A free, beautiful, data-collecting carousel builder whose entire purpose is to get publishers curious enough to click a "ND Profile →" link and land on Nashville Decoder. It is NOT a monetized product. It generates Instagram handle confirmations and Apple Music composer data that feed Nashville Decoder via the Convergence Engine — this is Patent Candidate 2 in the business strategy doc and both mechanisms are live in production.
+
+**The money flow** (mid-May publisher demo is the forcing function):
+1. Publisher sees NMF carousel on Instagram (18K follower reach)
+2. Slide shows "Written by Luke Laird — Sony Music Publishing (34 charting · 24 #1s)"
+3. Publisher visits `maxmeetsmusiccity.com/newmusicfriday`
+4. Clicks Coming Soon tab → bridge card with real upcoming track + songwriter credits
+5. Clicks "ND Profile →"
+6. Lands on `nashvilledecoder.com/profiles.html?id={pg_id}`
+7. Sales conversation starts
+
+**Every piece of this funnel exists and works as of Wave 6.** The gap is step 6 — ND's auth gate 302s unauthenticated visitors to Coming Soon. See §7 Known Upstream Blockers.
+
+---
+
+## 2. Repo + infra facts
+
+| Fact | Value |
+|---|---|
+| Repo | `~/Projects/mmmc-website` |
+| Branch | `main` (deploys directly — no PR flow) |
+| Deploy command | `npx vercel deploy --prod` |
+| Stack | Vite + React 19 + TypeScript, Vercel Functions (@vercel/node), Supabase |
+| Supabase project ref | `kpwklxrcysokuyjhuhun` |
+| Prod domain | `https://maxmeetsmusiccity.com` |
+| NMF route | `/newmusicfriday` |
+| Publisher demo page | `/demo/publisher-demo.html` |
+| Songwriter cache (static) | `/data/songwriter_cache.json` (11.9 MB raw) |
+| HEAD at Wave 6 end | `02bdb33` |
+
+### Secrets (all in `.env.local`, mirrored to Vercel env)
+
+| Key | Purpose |
+|---|---|
+| `VITE_SUPABASE_URL` | `https://kpwklxrcysokuyjhuhun.supabase.co` |
+| `SUPABASE_SERVICE_ROLE_KEY` | Server-side writes. **Gotcha**: the file stores it as `"<value>\n"` — literal quotes AND a literal `\n`. Strip both: `value.replace(/^"|"$/g, '').replace(/\\n$/, '')` in Node, or `sed 's/^"//; s/"$//; s/\\n$//'` in shell. |
+| `VITE_SUPABASE_ANON_KEY` | Client reads |
+| `CRON_SECRET` | cron handler auth — Bearer token |
+| `SCAN_SECRET` | /api/search-apple + /api/scan-artists auth — Bearer token |
+| `APPLE_MUSIC_TEAM_ID` | `G46PBQ4ZQL` |
+| `APPLE_MUSIC_KEY_ID` | `XP4Q9YVKQU` — **NEVER use `H8V2P37FRA`**, it returns 401 |
+| `APPLE_MUSIC_PRIVATE_KEY` | PKCS8 PEM in Vercel env |
+| `ND_API_BASE_URL` | `https://nd-api.nd-api.workers.dev` |
+| `ND_AUTH_TOKEN_SECRET` | HMAC secret for R2 API auth |
+
+### Endpoint auth patterns (non-obvious)
+
+- `/api/cron-scan-weekly` — `Authorization: Bearer $CRON_SECRET` header (fail-closed). Accepts query params: `week`, `offset`, `max_chains`, `chain`.
+- `/api/search-apple` — accepts EITHER `Bearer $SCAN_SECRET` OR `X-Supabase-Auth: <token>` OR `Origin: https://maxmeetsmusiccity.com`. Rate-limited 5 req/60s per IP.
+- `/api/songwriter-match` — unauthenticated (public lookup API), CORS-open, edge-cached 24h. **Returns both `matches` and `matches_by_input` (Wave 6 Block 5 addition — use this for client-side cache building keyed by raw input strings).**
+- `/api/enrichment-latest` — `Authorization: Bearer $CRON_SECRET` OR `X-ND-Token` header (Thread A reads this).
+- `/api/migrate` — **does not exist**; Supabase DDL must be pasted into the SQL editor manually.
+
+---
+
+## 3. Current test floor — NON-NEGOTIABLE
+
+**These numbers must never go down.** Every handoff memo must re-verify them before claiming anything.
+
+| Gate | Number | Command |
+|---|---|---|
+| TypeScript build | 0 errors | `npx tsc -b` (**NOT** `tsc --noEmit` — Vercel CI is stricter) |
+| Vitest | **393 / 393** | `npx vitest run` |
+| Playwright (localhost preview) | **27 passed + 4 skipped** | `npx playwright test` |
+| Playwright (against real prod) | **31 passed + 2 skipped** | `E2E_API_BASE=https://maxmeetsmusiccity.com npx playwright test` |
+
+**The 31+2 against prod is the HONEST number** — it's the first structurally-correct prod run in the repo's history (Wave 6 Block 4 wired `E2E_API_BASE` into `playwright.config.ts`; prior waves claimed "30/30 against prod" but the env var wasn't wired and the tests were actually hitting localhost except for 4 API tests that happened to hit prod).
+
+The 2 skipped are data-dependent: they exercise the Coming Soon tab funnel IF any future-dated release has `composer_name` populated. None do as of 2026-04-13 — upstream gap, will auto-activate when Thread A's composer enrichment catches up.
+
+### Before every commit, always run in this order:
+1. `npx tsc -b` — zero errors
+2. `npx vitest run` — 393/393
+3. `npx playwright test` — 27+4-skip minimum
+4. Only if touching the deployed funnel: `E2E_API_BASE=https://maxmeetsmusiccity.com npx playwright test` → 31+2-skip
+5. Paste the output into the commit message or session-end file if you're claiming "verified against prod"
+
+---
+
+## 4. Wave 6 summary — what landed
+
+| # | Commit | Block | Key change |
+|---|---|---|---|
+| 1 | `2b404e0` | BLOCK 1 | Replaced 11 placeholder pg_ids in publisher demo page with real ones from `/api/songwriter-match` live lookup |
+| 2 | `5b16571` | BLOCK 2 | Added `scan_runs.start_offset INTEGER DEFAULT 0`; fixed cron self-healing resume math to `start_offset + artists_scanned`; new Bug #2 regression test |
+| 3 | `3389420` | BLOCK 3 | Composer credits in `CarouselPreviewPanel.tsx` now only render on single-track slides (prevents 9-track-grid misattribution) |
+| 4 | `38bee0c` | BLOCK 4 | Wired `E2E_API_BASE` into `playwright.config.ts`; widened demo-page pg_id regex to accept `PG_AUTO_` prefix |
+| 5 | `d8eb7dd` | BLOCK 5 | `ComingSoon.tsx` switched from 12MB static cache fetch to per-release batch POST to `/api/songwriter-match`; API gained `matches_by_input` response field |
+| 6 | `02bdb33` | ADDENDUM #7 | 3 new Playwright tests for the live Coming Soon tab funnel; fixed `guestBypass` to actually click through AuthGate |
+
+### Infra change outside the repo
+- `scan_runs` table: `ALTER TABLE scan_runs ADD COLUMN IF NOT EXISTS start_offset INTEGER DEFAULT 0;` — applied via Supabase SQL editor. Migration file in repo: `migrations/002_scan_runs_start_offset.sql`.
+
+---
+
+## 5. The three Wave-5-inherited bugs are all fixed
+
+All three bugs called out in `docs/CONTINUITY_MEMO__THREAD_C__2026-04-12.md` as "fix first" are now fixed AND verified:
+
+1. ✅ **Fake pg_ids in demo page** (Bug #1) → Block 1
+2. ✅ **Cron self-healing offset math** (Bug #2) → Block 2 (+ live integration test via `week=2099-01-02&offset=999999`)
+3. ✅ **Composer credits misleading attribution** (Bug #3) → Block 3 (Option A chosen)
+
+---
+
+## 6. Three latent Wave 5 bugs ALSO found and fixed
+
+These were never called out in the Wave 5 handoff — I found them mid-Wave-6 while trying to verify my own work. They matter because their fixes unlocked the rest of Wave 6's verification.
+
+### Latent Bug A — `E2E_API_BASE` was never wired into `playwright.config.ts`
+Waves 1-5 all claimed "30/30 passing against live prod". Actually running `E2E_API_BASE=https://maxmeetsmusiccity.com npx playwright test` sent the API tests to prod (they build full URLs from the env var) but sent ALL page-navigation tests to `http://localhost:4173` because the config hardcoded `baseURL` there. Split-brain. Fixed in Block 4.
+
+### Latent Bug B — Stale dist + `reuseExistingServer: true` = silent false positives
+Playwright's webServer config reuses an existing `:4173` server if one is running. When combined with `dist/` being stale (not rebuilt since the last edit), tests can pass against old code while the developer thinks they pass against new code. This was exactly how my initial "30/30 after Block 3" was fake — the dist had Wave 5's placeholder pg_ids, and the regex tested `/^...\?id=pg_/` which was case-sensitive and happened to match the old lowercase placeholders. Fixed by explicit rebuild + force; see §9 recommendation #2 for the permanent fix.
+
+### Latent Bug C — `guestBypass` helper never actually entered the app
+The helper at `tests/e2e/smoke.spec.ts:4` only set `localStorage.nmf_guest_mode=1`. But `AuthGate` checks `sessionStorage.nmf_entered` which is only set by clicking the "Get Started as a Guest" button. So guestBypass left the browser on the AuthGate landing page. The existing smoke test `NMF page loads with guest mode` happened to pass because the landing page ALSO renders a `<h1>New Music Friday</h1>` heading — same text, different component. Every prior "NashvilleReleases guest mode" assertion was actually asserting against the landing page. Fixed in Addendum #7 by adding a new `openNmfAsGuest` helper that clicks the button.
+
+### Why these matter for Wave 7
+Your predecessor's test-floor claims were unreliable because of these. **Don't trust ANY "verified against prod" claim in a memo unless you see a timestamped output of `E2E_API_BASE=... npx playwright test` pasted in verbatim.** The §3 floor above IS timestamped — Wave 6 ran all four gates at 2026-04-13 before writing this memo.
+
+---
+
+## 7. Known upstream blockers (not Thread C work)
+
+### Blocker A — ND auth lockdown makes the publisher funnel unreachable
+Every `nashvilledecoder.com/profiles.html?id=<pg_id>` 302s to the Coming Soon landing page for unauthenticated visitors. Including known-good `pg_df752e8c5e64` (Ashley Gorley) and deliberately bogus ids. This is the **Da Vinci Code auth gate**, not a routing bug. Block 1 correctly swapped 11 placeholder pg_ids to real ones, but publishers clicking any ND Profile link today still lands on Coming Soon. 
+
+**Cross-thread ask**: `/tmp/cross_thread_request_c_to_ui.md` — Thread UI / Thread A needs to confirm the publisher demo auth mechanism. Options: pre-set cookie, `?demo=<hmac_token>` query param, public `/p/<pg_id>` route, or localhost:8765 workaround.
+
+**Thread C cannot close this alone.** Mid-May demo is blocked on it.
+
+### Blocker B — Zero future-dated releases have `composer_name` populated
+242 future-dated releases exist in `weekly_nashville_releases` (scan_week=2026-04-10), but **zero** have `composer_name`. So the live Coming Soon tab renders zero bridge cards with songwriter stats today. The Playwright tests I added in Addendum #7 gracefully skip on this, but that means the only thing verifying the funnel end-to-end right now is the navigation path, not the actual data rendering.
+
+**Partial unblock Thread C can do**: write a one-shot backfill script that queries `weekly_nashville_releases WHERE composer_name IS NULL AND release_date > today`, calls `/api/search-apple` for each track, and UPSERTs. ~100-300 rows, ~$0.50 cost. Recommended as Wave 7 block 1.
+
+### Blocker C — Songwriter cache publisher coverage at 0.3%
+158 / 61,668 writers have publisher strings in `songwriter_cache.json`. Thread A delivered `dim_publisher_roster_v1` (387 rows, 54 publishers with tier classification) but the cache hasn't been regenerated against it. Wave 5 addendum #6 says to run `python3 scripts/regenerate_cache_if_stale.py --force` once Thread A confirms cascade + R2 upload is done. **Status at end of Wave 6**: waiting on Thread A confirmation.
+
+---
+
+## 8. Scope doc — what NMF must never become
+
+From `docs/NMF_SCOPE.md`:
+
+**Approved**:
+- Carousel builder (This Week + Coming Soon)
+- Bridge cards with songwriter charting stats + ND Profile links
+- Carousel slides with songwriter credits (Instagram funnel)
+- Handle confirmation button (data collection)
+- Showcase filtering, progressive rendering, mobile polish
+- ZIP/image download, Save to Photos
+
+**Prohibited** (would cannibalize Nashville Decoder's paid product):
+- Songwriter search field
+- Publisher intelligence display beyond basic names
+- Email digest (belongs on ND)
+- Any feature that makes NMF a standalone product instead of a funnel
+
+If you're ever unsure whether to build something, read the scope doc. If it's not in the approved list, say no unless Max explicitly overrides.
+
+---
+
+## 9. Operating rules — carry-over from Wave 5 + Wave 6 additions
+
+These rules exist because of specific session-ending bugs. Not suggestions.
+
+1. **Always `npx tsc -b` before committing, never just `tsc --noEmit`.** Vercel CI is stricter.
+2. **Always smoke-test new Vercel functions against production** immediately after deploy. Vitest + tsc do not catch runtime TDZ errors or fs/bundle assumptions.
+3. **Fetch static assets via HTTP from CDN**, not via `fs` in serverless functions. `public/` is NOT in the function bundle.
+4. **Use `git commit -F /tmp/msg.txt`** for messages with parentheses or special characters. Heredoc escaping will bite you.
+5. **Write Python as files in `/tmp/`**, not as heredocs. Heredoc variable expansion corrupts `r['id']` as `KeyError: <built-in function id>`.
+6. **Supabase service role key has quotes AND `\n` literal** in `.env.local`. Strip both: `sed 's/^"//; s/"$//; s/\\n$//'`.
+7. **Click your own work.** If a link exists, click it. If a button exists, tap it. Don't trust "the test passes" — Wave 5's dead pg_ids shipped because nobody clicked them, and Wave 5's guestBypass was structurally broken because nobody verified it actually reached the app.
+8. **Commit after every block, push immediately**, max 1 hour of uncommitted work. Session-level commit batching will bite you.
+9. **End every session by re-running the full test suite AND hitting live endpoints.** No handoff memo without a timestamped test run pasted in.
+10. **Read `docs/NMF_SCOPE.md`** before building anything new.
+
+### Wave 6 additions:
+11. **When Playwright fails "element intercepts pointer events"**, jump straight to `element.evaluate((e) => e.click())`. Don't iterate through `force: true`; it's rarely the fix.
+12. **Before trusting any "31/30 against prod" number, verify `playwright.config.ts` actually uses `E2E_API_BASE`.** If `baseURL` is hardcoded, the claim is probably split-brain.
+13. **Before trusting any Playwright test that uses the guest-bypass helper, verify the helper actually clicks "Get Started as a Guest".** A landing-page assertion is not an in-app assertion.
+14. **If you rebuild `dist/` mid-session, kill :4173 first** (or set `reuseExistingServer: false` for that run) to avoid stale-dist false positives.
+15. **When writing integration tests that touch live Supabase**, use a far-future `week=2099-XX-XX` + far-past-end `offset=999999` pattern to avoid burning scan quota, and always save+restore `scan_metadata` around the test. See Wave 6 Block 2 integration test for the canonical pattern.
+
+---
+
+## 10. Cross-thread contracts — files you produce for others
+
+| File | Consumer | When to regenerate |
+|---|---|---|
+| `data/nmf_handle_sync.json` | Thread A cascade | After any batch of NMF handle confirmations (`scripts/sync_handles_to_nd.py`) |
+| `public/data/featured_artists_stats.json` | Thread D trending algo | After cascade or weekly (`scripts/export_featured_stats.py`) |
+| `api/enrichment-latest` endpoint | Thread A cascade | Live — served on-demand, edge-cached 1h |
+| `public/data/songwriter_cache.json` | NMF client + any surface needing writer stats | After Thread A cascade updates ND DB (`scripts/regenerate_cache_if_stale.py`) |
+
+**Thread C NEVER writes** to another thread's repo. Communication: files in `/tmp/cross_thread_request_c_to_<x>.md` or Max forwarding messages.
+
+---
+
+## 11. Risk mitigation steps — Wave 7 opening priorities
+
+Extracted from the Top 10 Recommendations document. Listed in priority order for Wave 7:
+
+### Priority 1 (must do in Wave 7's first hour — structural hardening)
+- **R2 — Kill the stale-dist foot-gun.** Add `pretest` hook to rebuild dist, or set `reuseExistingServer: false` when E2E_API_BASE is not set. 10 min. Prevents another Block-4-style silent failure.
+- **R9 — Session-end verification ritual.** Write `scripts/session-end-verify.sh` that runs all four gates in order, and mandate it in the operating rules. 15 min. Structurally enforces handoff honesty.
+- **R1 — `npm run test:prod` command.** Add to `package.json` so the canonical prod test is a single keystroke. 15 min. Prevents forgetting the env var.
+
+### Priority 2 (unblock the publisher demo funnel)
+- **R5 — ND auth bypass for demo.** Cross-thread with Thread UI / Thread A. Design the signed-token or public-route option. 1-2 hr of coordination + implementation.
+- **R6 — Composer enrichment backfill.** One-shot script to populate `composer_name` on existing future releases. Unlocks the two vacuous Playwright tests + the real Coming Soon bridge card rendering. 45 min.
+
+### Priority 3 (quality-of-life + compounding wins)
+- **R3 — Guest-mode E2E sanity test.** Retire the 5-wave ghost bug permanently. 10 min.
+- **R4 — Normalize `.env.local` service role key.** Remove the every-session sed-strip friction. 20 min.
+- **R7 — CarouselPreviewPanel perf optimization.** Mirror Block 5's pattern. Same file, same API, new surface. 30 min.
+- **R8 — Publisher funnel analytics.** Click tracking + dashboard for the one metric that matters. 1-2 hr.
+
+### Priority 4 (template + documentation)
+- **R10 — Continuity memo template.** Promote this memo's structure to `docs/templates/` so other threads can adopt it. 40 min.
+
+**Recommended Wave 7 sequence**: Do Priority 1 first (45 min of pure hardening before touching anything else), then decide between Priority 2A (R5 cross-thread) or Priority 2B (R6 backfill) based on whether Thread UI is available. Priority 3 fits into the remaining session. Priority 4 can slide to Wave 8 if Wave 7 is tight.
+
+---
+
+## 12. Opportunity seizure — where to push harder
+
+1. **`matches_by_input` is reusable beyond ComingSoon.** Any surface rendering writer stats can now drop the 12MB static cache. CarouselPreviewPanel is the obvious next target (R7), but future surfaces like email digests, analytics panels, or showcase readouts can all use the same pattern.
+
+2. **The Playwright-against-prod path is now real.** Run it on a daily cron as a health check. If the live funnel breaks (e.g., ND pulls a change that affects profile URLs, Supabase schema changes, scan pipeline crashes), you'll know within 24 hours instead of at demo time.
+
+3. **`scan_runs.start_offset` observability is now correct.** Wave 3 identified a `composer_credits_found` trend dashboard as "pending". Now that the observability table is trustworthy, it's the right time to build it — a simple Supabase view + `/api/observability-summary` endpoint + rendered panel on a private debug page.
+
+4. **Block 2 integration-test pattern is reusable.** The save-scan_metadata → trigger-cron-with-2099-week → verify-row → delete-test-row → restore-scan_metadata dance works for any future cron-handler integration test. Could be a `tests/integration/` directory with a shared helper.
+
+5. **The Wave 5 handoff's "30/30 against prod" fiction is now exposed.** Make honesty contagious — write the session-end verify script in a way that OUTPUTS the test result to a timestamped file, so handoff memos can reference that file rather than paraphrasing it. Structural drift prevention.
+
+6. **NMF is the Trojan Horse, and the funnel is HTML-correct.** Once ND auth is resolved (R5), every real publisher who sees an NMF carousel on Instagram becomes a potential conversion. Anything that reduces friction between "Instagram view" and "ND profile click" is worth more than new features.
+
+---
+
+## 13. First hour of Wave 7 — suggested opening move
+
+Don't jump into a block. Do hardening first.
+
+```bash
+# 1. Verify the floor holds
+cd ~/Projects/mmmc-website
+git status --short                                        # should be near-clean
+git log --oneline -7                                      # should show Wave 6 commits ending at 02bdb33
+npx tsc -b                                                # 0 errors
+npx vitest run                                            # 393/393
+npx playwright test                                       # 27+4-skip
+E2E_API_BASE=https://maxmeetsmusiccity.com npx playwright test   # 31+2-skip
+```
+
+Every number above must match. If ANY is off, stop and investigate before proceeding.
+
+```bash
+# 2. Verify live surface
+curl -s -o /dev/null -w "%{http_code}\n" https://maxmeetsmusiccity.com/newmusicfriday           # 200
+curl -s -o /dev/null -w "%{http_code}\n" https://maxmeetsmusiccity.com/demo/publisher-demo.html # 200
+curl -s -X POST https://maxmeetsmusiccity.com/api/songwriter-match \
+  -H "Content-Type: application/json" \
+  -d '{"composer_names":["Ashley Gorley"]}' | head -1                                            # has pg_df752e8c5e64
+```
+
+```bash
+# 3. Do the Priority 1 hardening (45 minutes total)
+# - Add pretest hook to package.json (R2, 10 min)
+# - Write scripts/session-end-verify.sh (R9, 15 min)
+# - Add npm run test:prod script (R1, 15 min)
+# Commit as a single "[Wave 7 HARDENING] ..." commit.
+```
+
+Only then start the real work. The hardening commit means every subsequent claim in Wave 7 is verifiable structurally.
+
+---
+
+## 14. Ask Max these questions in the first exchange
+
+1. Has Thread A confirmed cascade + R2 upload is done? If yes, run `python3 scripts/regenerate_cache_if_stale.py --force` before anything else.
+2. Has Thread UI / Thread A made a call on the ND auth bypass for the publisher demo? (Blocker A.) If yes, get the mechanism and wire Thread C's side.
+3. Are there new Wave 6 commits or rollbacks on nashvilledecoder.com that would change which pg_ids are valid? (Sanity check — if Thread A reshuffled entity IDs, the demo page links may need regenerating.)
+4. Is there anything urgent for mid-May demo prep that outranks the R1/R2/R9 hardening? If yes, do it first. Otherwise hardening wins.
+
+---
+
+## 15. Final reminder: the one number that matters
+
+**Publisher demo conversion: carousel view → ND Profile link click.**
+
+Everything in Wave 7 (and every future wave) is ranked against this metric. The funnel HTML is correct. The blocker is upstream (ND auth). When that's solved, every other improvement compounds.
+
+---
+
+*End of memo. Wave 6 author-thread context rating: 6/10 at session close. This memo is written to let a fresh thread hit the ground running at 10/10. If you're reading this in Wave 7 — read §3 and §9 first, then §7 blockers, then §11 priorities, then start with §13's first hour.*


### PR DESCRIPTION
Per strategy 11:50 CT ACK of NMF disposition Option C (split commit) — Max Q9 ruling.

## Summary
Consolidates the durable agent-infra pieces from long-lived feature branch `zeta/w4-sw2-tier1-polish`:
- `.claude/CLAUDE.md` (+23 lines) — debrief protocol, signal conventions, skill trigger table
- `.claude/skills/` — 11 skill markdown files (canary, cascade, debrief, deploy, eyeball, gate, handshake, investigate, preflight, recon, scope)
- `cross_thread` — symlink to shared signals directory in main cowritecompass repo
- `docs/CONTINUITY_MEMO__THREAD_C__2026-04-13.md` — continuity memo
- `.gitignore` — adds `supabase/.temp/` (Supabase CLI scratch)

## What's NOT in this PR
- NMF data additions (`data/nmf_handle_sync.json`) — stays on feature branch until NMF Curator Studio roadmap is decided
- Dashboard grid tweak (`src/pages/Dashboard.tsx`) — stays on feature branch

## Test plan
- [ ] CI green
- [ ] Merge clean to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)