### PR TITLE
api: harden NMF ND proxy allowlist

### DIFF
--- a/api/nd-proxy.ts
+++ b/api/nd-proxy.ts
@@ -1,15 +1,78 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
-// Strict whitelist — only NMF-safe endpoints allowed through the proxy
+const NMF_SAFE_PROFILE_PATHS = [
+  '/api/profile/instagram',
+  '/api/profile/search',
+  '/api/profile/research-agent',
+] as const;
+
+const DENIED_PROFILE_PATH_PREFIXES = [
+  '/api/profile/credit',
+  '/api/profile/royalty',
+  '/api/profile/private',
+] as const;
+
 const ALLOWED_PATH_PREFIXES = [
   '/api/nmf/browse',
   '/api/nmf/collaborators',
   '/api/nmf/instagram',
   '/api/nmf/releases',
   '/api/search',
-  '/api/profile/',
   '/api/research/',
-];
+] as const;
+
+const HOUR_MS = 60 * 60 * 1000;
+const MINUTE_MS = 60 * 1000;
+const hourlyHits = new Map<string, number[]>();
+const burstHits = new Map<string, number[]>();
+
+function startsWithPath(path: string, prefix: string): boolean {
+  return path === prefix || path.startsWith(`${prefix}/`) || path.startsWith(`${prefix}?`);
+}
+
+export function isDeniedPath(path: string): boolean {
+  return DENIED_PROFILE_PATH_PREFIXES.some((prefix) => startsWithPath(path, prefix));
+}
+
+export function isAllowedPath(path: string): boolean {
+  if (isDeniedPath(path)) return false;
+  if (NMF_SAFE_PROFILE_PATHS.some((prefix) => startsWithPath(path, prefix))) {
+    return true;
+  }
+  if (path.startsWith('/api/profile/')) return false;
+  return ALLOWED_PATH_PREFIXES.some((prefix) => startsWithPath(path, prefix));
+}
+
+function clientIp(req: VercelRequest): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string') return forwarded.split(',')[0].trim();
+  if (Array.isArray(forwarded)) return forwarded[0]?.split(',')[0]?.trim() ?? 'unknown';
+  return req.socket?.remoteAddress ?? 'unknown';
+}
+
+function recordHit(
+  store: Map<string, number[]>,
+  key: string,
+  now: number,
+  windowMs: number,
+  maxHits: number
+): boolean {
+  const hits = (store.get(key) ?? []).filter((ts) => now - ts < windowMs);
+  hits.push(now);
+  store.set(key, hits);
+  return hits.length > maxHits;
+}
+
+export function resetProxyRateLimitForTests(): void {
+  hourlyHits.clear();
+  burstHits.clear();
+}
+
+export function isProxyRateLimited(ip: string, now = Date.now()): boolean {
+  const hourlyLimited = recordHit(hourlyHits, ip, now, HOUR_MS, 60);
+  const burstLimited = recordHit(burstHits, ip, now, MINUTE_MS, 10);
+  return hourlyLimited || burstLimited;
+}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   // ── Path validation (BEFORE any proxy logic) ──
@@ -24,10 +87,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(403).json({ error: 'Forbidden' });
   }
 
-  // Whitelist check — path must start with an allowed prefix
-  const isAllowed = ALLOWED_PATH_PREFIXES.some(p => path.startsWith(p));
-  if (!isAllowed) {
+  if (!isAllowedPath(path)) {
     return res.status(403).json({ error: 'Path not allowed' });
+  }
+
+  if (isProxyRateLimited(clientIp(req))) {
+    return res.status(429).json({ error: 'Rate limit exceeded' });
   }
 
   // ── Proxy logic ──

--- a/tests/unit/nd-proxy.test.ts
+++ b/tests/unit/nd-proxy.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import handler, {
+  isAllowedPath,
+  isDeniedPath,
+  isProxyRateLimited,
+  resetProxyRateLimitForTests,
+} from '../../api/nd-proxy';
+
+function mockReq(path: string, ip = '203.0.113.10') {
+  return {
+    query: { path },
+    method: 'GET',
+    headers: { 'x-forwarded-for': ip },
+    socket: { remoteAddress: ip },
+  } as any;
+}
+
+function mockRes() {
+  const res: any = {
+    statusCode: 200,
+    body: undefined,
+    status: vi.fn((code: number) => {
+      res.statusCode = code;
+      return res;
+    }),
+    json: vi.fn((body: unknown) => {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
+}
+
+describe('NMF ND proxy path policy', () => {
+  it('allows only NMF-safe profile endpoints', () => {
+    expect(isAllowedPath('/api/profile/instagram')).toBe(true);
+    expect(isAllowedPath('/api/profile/search?q=writer')).toBe(true);
+    expect(isAllowedPath('/api/profile/research-agent/pg_123')).toBe(true);
+  });
+
+  it('denies sensitive profile endpoints', () => {
+    expect(isDeniedPath('/api/profile/credit')).toBe(true);
+    expect(isDeniedPath('/api/profile/royalty/pg_123')).toBe(true);
+    expect(isDeniedPath('/api/profile/private?pg_id=123')).toBe(true);
+    expect(isAllowedPath('/api/profile/credit')).toBe(false);
+    expect(isAllowedPath('/api/profile/royalty/pg_123')).toBe(false);
+    expect(isAllowedPath('/api/profile/private?pg_id=123')).toBe(false);
+  });
+
+  it('denies broad profile paths by default', () => {
+    expect(isAllowedPath('/api/profile/pg_123')).toBe(false);
+    expect(isAllowedPath('/api/profile/cowriters/pg_123')).toBe(false);
+  });
+});
+
+describe('NMF ND proxy rate limit', () => {
+  beforeEach(() => resetProxyRateLimitForTests());
+
+  it('blocks the eleventh request in the 10/min burst window', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 10; i++) {
+      expect(isProxyRateLimited('203.0.113.10', now + i)).toBe(false);
+    }
+    expect(isProxyRateLimited('203.0.113.10', now + 10)).toBe(true);
+  });
+});
+
+describe('NMF ND proxy handler blocks denied paths before upstream fetch', () => {
+  beforeEach(() => {
+    resetProxyRateLimitForTests();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('returns 403 for denylisted profile paths', async () => {
+    const res = mockRes();
+
+    await handler(mockReq('/api/profile/royalty/pg_123'), res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.body).toEqual({ error: 'Path not allowed' });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Narrows the ND proxy profile allowlist to NMF-safe paths only:
  - `/api/profile/instagram`
  - `/api/profile/search`
  - `/api/profile/research-agent`
- Adds explicit denylist for sensitive profile path families:
  - `/api/profile/credit`
  - `/api/profile/royalty`
  - `/api/profile/private`
- Blocks all other broad `/api/profile/*` paths by default.
- Adds subscription-free in-memory per-IP rate limiting: 60/hour and 10/minute burst.
- Adds unit tests for allowlist, denylist, deny-before-fetch, and burst limiting.

## Verification

- `npm install --silent`: PASS
- `npm test -- --run tests/unit/nd-proxy.test.ts`: PASS; 1 file / 5 tests
- `npx tsc -b --pretty false`: PASS
- `npm run build`: PASS
- `npm test`: PASS; 39 files / 486 tests
- `git diff --check`: PASS

## Notes

I worked in a fresh clone at `/private/tmp/codex-a-nmf-proxy` because `~/Projects/nmf-curator-studio` currently exists but is not a git checkout locally.
