### PR TITLE
[BUILD-3-W15-NMF-CSP-BASELINE] Add CSP report-only baseline

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,8 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        { "key": "Content-Security-Policy-Report-Only", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://nd-api.nd-api.workers.dev https://*.upstash.io https://api.spotify.com https://api.music.apple.com https://www.googleapis.com https://api.apify.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Adds `Content-Security-Policy-Report-Only` header to NMF Curator Studio per file 178 §1 op 4 (Q4 CSP per product)
- Closes Build-3 1620 Q4 GAP (NMF lacked CSP entirely · only HSTS active)
- Report-Only mode → reports violations without blocking · safe to ship

## CSP scope
Defensive baseline for Vite SPA. connect-src allowlist sourced from NMF production env vars (Apple Music, Spotify, Upstash Redis, Google CSE, Apify, Supabase, nd-api Worker).

## Test plan
- [x] Local: vercel.json valid JSON
- [ ] Post-merge: curl https://maxmeetsmusiccity.com/ + grep `content-security-policy-report-only` header
- [ ] Codex-G refines per-product CSP spec post-Wave-4 (this baseline is interim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>