### PR TITLE
NMF Phase 2: add Marquee v2 title dispatch

### DIFF
--- a/src/lib/canvas-grid.ts
+++ b/src/lib/canvas-grid.ts
@@ -1,7 +1,8 @@
 import type { SelectionSlot } from './selection';
 import type { CarouselTemplate } from './carousel-templates';
 import { getTemplate } from './carousel-templates';
-import { getTitleTemplate, type TitleSlideTemplate } from './title-templates';
+import { getTitleTemplate, getV2TitleTemplatePreset, type TitleSlideTemplate } from './title-templates';
+import { preloadV2TemplateAssets, renderTitleSlide } from './canvas-renderer-v2';
 import { drawCustomElements, type EditorElement } from './editor-elements';
 import { type GridConfig, getGridById, getGridsForCount, computeCellRects } from './grid-layouts';
 import { computeLastFriday } from './scan-utils';
@@ -240,10 +241,14 @@ function goldRule(ctx: CanvasRenderingContext2D, y: number, t: CarouselTemplate)
 function drawNotes(ctx: CanvasRenderingContext2D, size: number) {
   const gi = (key: string) => imageCache.get(key)?.img ?? null;
   const cw = ctx.canvas.width, ch = ctx.canvas.height;
-  const tl = gi(ASSETS.noteTL); tl && ctx.drawImage(tl, 52, 52, size * 0.7, size);
-  const tr = gi(ASSETS.noteTR); tr && ctx.drawImage(tr, cw - 52 - size * 0.65, 52, size * 0.65, size);
-  const bl = gi(ASSETS.noteBL); bl && ctx.drawImage(bl, 52, ch - 52 - size * 0.85, size * 0.85, size);
-  const br = gi(ASSETS.noteBR); br && ctx.drawImage(br, cw - 52 - size * 0.85, ch - 52 - size * 0.85, size * 0.85, size);
+  const tl = gi(ASSETS.noteTL);
+  if (tl) ctx.drawImage(tl, 52, 52, size * 0.7, size);
+  const tr = gi(ASSETS.noteTR);
+  if (tr) ctx.drawImage(tr, cw - 52 - size * 0.65, 52, size * 0.65, size);
+  const bl = gi(ASSETS.noteBL);
+  if (bl) ctx.drawImage(bl, 52, ch - 52 - size * 0.85, size * 0.85, size);
+  const br = gi(ASSETS.noteBR);
+  if (br) ctx.drawImage(br, cw - 52 - size * 0.85, ch - 52 - size * 0.85, size * 0.85, size);
 }
 
 function drawSparkles(ctx: CanvasRenderingContext2D, positions: [number, number][], sz: number) {
@@ -410,6 +415,37 @@ export async function generateTitleSlide(
     : templateOrId;
   const dim = getDimensions(aspect);
   const W = dim.w, H = dim.h;
+
+  const v2Template = getV2TitleTemplatePreset(tt);
+  if (v2Template) {
+    const canvas = document.createElement('canvas');
+    canvas.width = W; canvas.height = H;
+    const ctx = canvas.getContext('2d')!;
+    const featured = coverFeature ? {
+      id: coverFeature.track.track_id,
+      title: coverFeature.track.track_name,
+      artist: coverFeature.track.artist_names,
+      cover: coverFeature.track.cover_art_640,
+    } : undefined;
+    await preloadV2TemplateAssets(v2Template, featured ? [featured] : []);
+    await renderTitleSlide(ctx, W, H, {
+      template: v2Template,
+      title: 'New Music Friday',
+      subtitle: 'Max Meets Music City',
+      edition: formatDate(weekDate),
+      featured,
+      count: coverFeature ? 1 : 0,
+    });
+    if (customElements?.length) {
+      await drawCustomElements(ctx, customElements, W, H);
+    }
+    return new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(b => {
+        if (b) resolve(b);
+        else reject(new Error('Canvas toBlob returned null — canvas may be tainted or browser ran out of memory'));
+      }, 'image/png');
+    });
+  }
 
   // Pre-load fonts
   await Promise.all([

--- a/src/lib/carousel-templates.ts
+++ b/src/lib/carousel-templates.ts
@@ -1,7 +1,10 @@
+import type { TemplateEngine } from './template-types-v2';
+
 export interface CarouselTemplate {
   id: string;
   name: string;
   description: string;
+  engine?: TemplateEngine;
 
   // Colors
   background: string;
@@ -84,7 +87,7 @@ export interface CarouselTemplate {
   customElements?: import('./editor-elements').EditorElement[];
 }
 
-export const TEMPLATES: CarouselTemplate[] = [
+const LEGACY_TEMPLATES: CarouselTemplate[] = [
   {
     id: 'mmmc_classic',
     name: 'MMMC Classic',
@@ -369,6 +372,11 @@ export const TEMPLATES: CarouselTemplate[] = [
   },
 ];
 
+export const TEMPLATES: CarouselTemplate[] = LEGACY_TEMPLATES.map(template => ({
+  engine: 'v1',
+  ...template,
+}));
+
 /** Templates that are exclusive to Max's account */
 export const MAX_ONLY_TEMPLATES = new Set(['mmmc_classic', 'neon_rose', 'golden_hour']);
 
@@ -388,7 +396,7 @@ export function getTemplate(id: string): CarouselTemplate {
 
 /** Get templates visible to a user (filters out Max-only for other users) */
 export function getVisibleTemplates(userEmail?: string): CarouselTemplate[] {
-  const isMax = userEmail === 'maxmeetsmusiccity@gmail.com' || userEmail === 'maxblachman@gmail.com';
+  const isMax = userEmail === 'maxmeetsmusiccity@gmail.com';
   if (isMax) return TEMPLATES;
   return TEMPLATES.filter(t => !MAX_ONLY_TEMPLATES.has(t.id));
 }

--- a/src/lib/title-templates.ts
+++ b/src/lib/title-templates.ts
@@ -1,3 +1,6 @@
+import { V2_TITLE_TEMPLATE_PRESETS } from './brand-tokens';
+import type { TemplateEngine, V2TitleSlideTemplate } from './template-types-v2';
+
 /**
  * 10 Title Slide Templates for New Music Friday carousels.
  * Based on research of country music media visual trends (2025-2026).
@@ -9,6 +12,8 @@ export interface TitleSlideTemplate {
   id: string;
   name: string;
   description: string;
+  engine?: TemplateEngine;
+  v2PresetId?: string;
 
   // Colors
   background: string;
@@ -77,7 +82,7 @@ export interface TitleSlideTemplate {
   customElements?: import('./editor-elements').EditorElement[];
 }
 
-export const TITLE_TEMPLATES: TitleSlideTemplate[] = [
+const LEGACY_TITLE_TEMPLATES: TitleSlideTemplate[] = [
   // 1. Nashville Neon
   {
     id: 'nashville_neon',
@@ -498,6 +503,44 @@ export const TITLE_TEMPLATES: TitleSlideTemplate[] = [
   },
 ];
 
+const V2_MARQUEE_TITLE_TEMPLATE: TitleSlideTemplate = {
+  id: 'v2_marquee',
+  name: 'Velvet Marquee v2',
+  description: 'Renderer v2 theater marquee with plush rose, bulbs, and rotated feature art',
+  engine: 'v2',
+  v2PresetId: 'v2_marquee',
+  background: '#1a0f17',
+  textPrimary: '#FFD7A8',
+  textSecondary: '#c9a387',
+  accent: '#FF69B4',
+  headlineFont: '"Playfair Display", serif',
+  subtitleFont: '"Source Serif 4", serif',
+  dateFont: '"JetBrains Mono", monospace',
+  headlineWeight: 700,
+  headlineCase: 'capitalize',
+  headlineSize: 0.062,
+  subtitleSize: 0.024,
+  dateSize: 0.026,
+  headlineX: 0.5, headlineY: 0.08,
+  subtitleX: 0.5, subtitleY: 0.16,
+  dateX: 0.5, dateY: 0.9,
+  featuredImageX: 0.5, featuredImageY: 0.2,
+  featuredImageSize: 0.5,
+  glow: { color: 'rgba(255,105,180,0.34)', blur: 38, passes: 4 },
+  grain: 0.05,
+  vignette: 0.24,
+  showFrame: true, frameColor: '#FFD7A8', frameWidth: 8,
+  showDivider: true, dividerColor: 'rgba(255,215,168,0.42)',
+  featuredBorder: 8, featuredBorderColor: '#FFD7A8', featuredShadowBlur: 32, featuredRotation: -3,
+  texture: 'grain',
+  swipePill: true,
+};
+
+export const TITLE_TEMPLATES: TitleSlideTemplate[] = [
+  V2_MARQUEE_TITLE_TEMPLATE,
+  ...LEGACY_TITLE_TEMPLATES.map(template => ({ engine: 'v1' as const, ...template })),
+];
+
 /** Title templates that are exclusive to Max's account */
 export const MAX_ONLY_TITLE_TEMPLATES = new Set(['nashville_neon', 'vinyl_classic', 'gold_frame', 'spotlight', 'polaroid_stack']);
 
@@ -505,9 +548,15 @@ export function getTitleTemplate(id: string): TitleSlideTemplate {
   return TITLE_TEMPLATES.find(t => t.id === id) || TITLE_TEMPLATES[0];
 }
 
+export function getV2TitleTemplatePreset(template: TitleSlideTemplate): V2TitleSlideTemplate | undefined {
+  if (template.engine !== 'v2') return undefined;
+  const id = template.v2PresetId || template.id;
+  return V2_TITLE_TEMPLATE_PRESETS.find(t => t.id === id);
+}
+
 /** Get title templates visible to a user (filters out Max-only for other users) */
 export function getVisibleTitleTemplates(userEmail?: string): TitleSlideTemplate[] {
-  const isMax = userEmail === 'maxmeetsmusiccity@gmail.com' || userEmail === 'maxblachman@gmail.com';
+  const isMax = userEmail === 'maxmeetsmusiccity@gmail.com';
   if (isMax) {
     // Max-only templates first, then the rest
     const maxOnly = TITLE_TEMPLATES.filter(t => MAX_ONLY_TITLE_TEMPLATES.has(t.id));
@@ -519,7 +568,7 @@ export function getVisibleTitleTemplates(userEmail?: string): TitleSlideTemplate
 
 /** Get the default title template ID for a user */
 export function getDefaultTitleTemplateId(userEmail?: string): string {
-  const isMax = userEmail === 'maxmeetsmusiccity@gmail.com' || userEmail === 'maxblachman@gmail.com';
+  const isMax = userEmail === 'maxmeetsmusiccity@gmail.com';
   if (isMax) return 'vinyl_classic';
   const firstVisible = TITLE_TEMPLATES.find(t => !MAX_ONLY_TITLE_TEMPLATES.has(t.id));
   return firstVisible?.id || TITLE_TEMPLATES[0].id;

--- a/tests/unit/canvas-renderer-v2.test.ts
+++ b/tests/unit/canvas-renderer-v2.test.ts
@@ -12,6 +12,11 @@ import {
   radians,
   v2GridFromLegacy,
 } from '../../src/lib/canvas-renderer-v2';
+import {
+  getTitleTemplate,
+  getV2TitleTemplatePreset,
+  getVisibleTitleTemplates,
+} from '../../src/lib/title-templates';
 
 describe('canvas renderer v2 phase 1 surface', () => {
   it('normalizes design zip dash IDs to production-safe underscore IDs', () => {
@@ -65,6 +70,20 @@ describe('canvas renderer v2 phase 1 surface', () => {
     expect(marquee).toBeDefined();
     expect(marquee?.layout).toBe('marquee-frame');
     expect(marquee?.swipePillStyle).toBe('rose-tag');
+  });
+
+  it('exposes Marquee v2 through the title registry with engine dispatch metadata', () => {
+    const marquee = getTitleTemplate('v2_marquee');
+    expect(marquee.engine).toBe('v2');
+    expect(marquee.v2PresetId).toBe('v2_marquee');
+    expect(getV2TitleTemplatePreset(marquee)?.layout).toBe('marquee-frame');
+  });
+
+  it('keeps Marquee v2 visible while retaining the Max-only HeroSingle gate', () => {
+    const nonMax = getVisibleTitleTemplates('maxblachman@gmail.com').map(t => t.id);
+    expect(nonMax).toContain('v2_marquee');
+    expect(nonMax).not.toContain('vinyl_classic');
+    expect(getVisibleTitleTemplates('maxmeetsmusiccity@gmail.com').map(t => t.id)).toContain('vinyl_classic');
   });
 
   it('centralizes BB v2.1-adjacent brand colors for renderer presets', () => {

--- a/tests/unit/canvas-templates.test.ts
+++ b/tests/unit/canvas-templates.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   TEMPLATES,
   MAX_ONLY_TEMPLATES,
@@ -100,9 +100,9 @@ describe('getVisibleTemplates', () => {
     expect(visible).toHaveLength(TEMPLATES.length);
   });
 
-  it('returns all templates for Max (maxblachman@gmail.com)', () => {
+  it('treats maxblachman@gmail.com as non-Max', () => {
     const visible = getVisibleTemplates('maxblachman@gmail.com');
-    expect(visible).toHaveLength(TEMPLATES.length);
+    expect(visible).toHaveLength(TEMPLATES.length - MAX_ONLY_TEMPLATES.size);
   });
 
   it('filters out Max-only templates for other users', () => {
@@ -219,7 +219,7 @@ describe('getVisibleTitleTemplates', () => {
   });
 
   it('Max-only templates appear first for Max', () => {
-    const visible = getVisibleTitleTemplates('maxblachman@gmail.com');
+    const visible = getVisibleTitleTemplates('maxmeetsmusiccity@gmail.com');
     const firstFew = visible.slice(0, MAX_ONLY_TITLE_TEMPLATES.size);
     for (const t of firstFew) {
       expect(MAX_ONLY_TITLE_TEMPLATES.has(t.id)).toBe(true);
@@ -240,7 +240,6 @@ describe('getVisibleTitleTemplates', () => {
 describe('getDefaultTitleTemplateId', () => {
   it('returns vinyl_classic for Max', () => {
     expect(getDefaultTitleTemplateId('maxmeetsmusiccity@gmail.com')).toBe('vinyl_classic');
-    expect(getDefaultTitleTemplateId('maxblachman@gmail.com')).toBe('vinyl_classic');
   });
 
   it('returns a non-Max-only template for other users', () => {

--- a/tests/unit/templates.test.ts
+++ b/tests/unit/templates.test.ts
@@ -39,15 +39,15 @@ describe('carousel templates', () => {
     expect(visible.length).toBe(TEMPLATES.length);
   });
 
-  it('getVisibleTemplates shows all for maxblachman', () => {
+  it('getVisibleTemplates treats maxblachman as non-Max', () => {
     const visible = getVisibleTemplates('maxblachman@gmail.com');
-    expect(visible.length).toBe(TEMPLATES.length);
+    expect(visible.length).toBe(TEMPLATES.length - MAX_ONLY_TEMPLATES.size);
   });
 });
 
 describe('title templates', () => {
-  it('has 13 title templates (10 original + 3 new, no duplicates)', () => {
-    expect(TITLE_TEMPLATES.length).toBe(13);
+  it('has 14 title templates (13 v1 + Marquee v2, no duplicates)', () => {
+    expect(TITLE_TEMPLATES.length).toBe(14);
     // Verify no duplicate IDs
     const ids = TITLE_TEMPLATES.map(t => t.id);
     expect(new Set(ids).size).toBe(ids.length);
@@ -112,7 +112,7 @@ describe('title templates', () => {
 
   it('getDefaultTitleTemplateId returns vinyl_classic for Max, non-Max-only for others', () => {
     expect(getDefaultTitleTemplateId('maxmeetsmusiccity@gmail.com')).toBe('vinyl_classic');
-    expect(getDefaultTitleTemplateId('maxblachman@gmail.com')).toBe('vinyl_classic');
+    expect(MAX_ONLY_TITLE_TEMPLATES.has(getDefaultTitleTemplateId('maxblachman@gmail.com'))).toBe(false);
     expect(MAX_ONLY_TITLE_TEMPLATES.has(getDefaultTitleTemplateId('random@example.com'))).toBe(false);
   });
 });

--- a/tests/unit/title-defaults.test.ts
+++ b/tests/unit/title-defaults.test.ts
@@ -5,8 +5,8 @@ describe('title template defaults', () => {
   it('returns vinyl_classic for maxmeetsmusiccity@gmail.com', () => {
     expect(getDefaultTitleTemplateId('maxmeetsmusiccity@gmail.com')).toBe('vinyl_classic');
   });
-  it('returns vinyl_classic for maxblachman@gmail.com', () => {
-    expect(getDefaultTitleTemplateId('maxblachman@gmail.com')).toBe('vinyl_classic');
+  it('treats maxblachman@gmail.com as non-Max', () => {
+    expect(MAX_ONLY_TITLE_TEMPLATES.has(getDefaultTitleTemplateId('maxblachman@gmail.com'))).toBe(false);
   });
   it('returns first visible (non-Max-only) template for non-Max users', () => {
     const defaultId = getDefaultTitleTemplateId('user@example.com');


### PR DESCRIPTION
## Summary

- Adds `engine: 'v1' | 'v2'` metadata to carousel/title template registries while keeping legacy templates on v1.
- Publishes one live v2 title template wrapper, `v2_marquee`, mapped to the existing Renderer v2 Marquee preset.
- Dispatches title-slide generation by `engine`, sending v2 templates through `preloadV2TemplateAssets` + `renderTitleSlide` while preserving the existing v1/NeonText path.
- Tightens the Max-only gate to `maxmeetsmusiccity@gmail.com` only; `maxblachman@gmail.com` now receives non-Max visibility/defaults.

## Evidence

- `npm test -- --run tests/unit/canvas-renderer-v2.test.ts tests/unit/templates.test.ts tests/unit/canvas-templates.test.ts tests/unit/title-defaults.test.ts` passed: 4 files, 88 tests.
- `npx eslint src/lib/canvas-grid.ts src/lib/carousel-templates.ts src/lib/title-templates.ts tests/unit/canvas-renderer-v2.test.ts tests/unit/templates.test.ts tests/unit/canvas-templates.test.ts tests/unit/title-defaults.test.ts` passed.
- `npm run build` passed (`tsc -b && vite build`); Vite reported existing chunk-size and dynamic-import warnings.
- Dispatch evidence: `generateTitleSlide` resolves `getV2TitleTemplatePreset(tt)` and routes v2 templates to `renderTitleSlide`; v1 templates continue through the existing title renderer.