### PR TITLE
Converge website gold token to Brand Bible canon

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -3,11 +3,11 @@
   --midnight-raised: #162341;
   --midnight-hover: #1E2D4F;
   --midnight-border: #2A3A5C;
-  --gold: #D4A843;
+  --gold: #F5C453;
   --gold-light: #E8C675;
   --gold-dark: #B08A2E;
-  --gold-glow: rgba(212, 168, 67, 0.10);
-  --gold-glow-strong: rgba(212, 168, 67, 0.20);
+  --gold-glow: rgba(245, 196, 83, 0.10);
+  --gold-glow-strong: rgba(245, 196, 83, 0.20);
   --steel: #5E8EA8;
   --steel-light: #7BABC2;
   --steel-dark: #4A7189;


### PR DESCRIPTION
## Summary

- Converges the website canonical CSS Gold token from `#D4A843` to CWC/Brand Bible canonical `#F5C453`.
- Updates the derived Gold glow RGBA tokens to match the canonical Gold RGB channel.
- Leaves non-base Gold family tokens unchanged because this dispatch targeted the canonical base token drift.

## Per-product diff

- CWC canon: sampled `cowritecompass/src/components/persona/CohortSelfDeclareDrawer.tsx` already uses `#F5C453`.
- Website: `src/global.css` changed `--gold: #D4A843` to `--gold: #F5C453`, plus `--gold-glow` and `--gold-glow-strong` RGB alignment from `212, 168, 67` to `245, 196, 83`.

## Validation

- `git diff --check` passed.
- `npm run build` passed (`tsc -b && vite build`).
- `npm run lint` currently fails on pre-existing TypeScript/React lint debt outside `src/global.css` (113 errors), so it is not a clean gate for this CSS-only patch.

[pre-ack-request] Gold token drift fix ready for Strategy/Design review.