### PR TITLE
nmf: add Q12 Vercel audit forwarding

### DIFF
--- a/api/_audit.ts
+++ b/api/_audit.ts
@@ -1,0 +1,97 @@
+import type { VercelRequest } from '@vercel/node';
+import { createHash, randomUUID } from 'node:crypto';
+
+const DEFAULT_ND_API_BASE = 'https://nd-api.nd-api.workers.dev';
+const AUDIT_TIMEOUT_MS = 1800;
+
+type AuditOutcome = 'success' | 'failure' | 'unauthorized' | 'skipped';
+
+type AuditEvent = {
+  action: string;
+  outcome: AuditOutcome;
+  status?: number;
+  actor?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+function auditEndpoint(): string {
+  const explicit = process.env.Q12_AUDIT_ENDPOINT_URL || process.env.WORKERS_AUDIT_ENDPOINT_URL;
+  if (explicit) return explicit.trim();
+  const base = (process.env.ND_API_BASE_URL || DEFAULT_ND_API_BASE).replace(/\/$/, '');
+  return `${base}/api/admin/audit-log`;
+}
+
+function auditToken(): string {
+  return (
+    process.env.Q12_AUDIT_TOKEN ||
+    process.env.ADMIN_TOKEN ||
+    process.env.ND_ADMIN_TOKEN ||
+    ''
+  ).trim();
+}
+
+function hashActor(actor: string | null | undefined): string | null {
+  if (!actor) return null;
+  return createHash('sha256').update(actor).digest('hex').slice(0, 24);
+}
+
+function requestPath(req: VercelRequest): string {
+  try {
+    return new URL(req.url || '/', 'https://nmf.local').pathname;
+  } catch {
+    return req.url || 'unknown';
+  }
+}
+
+function clientIp(req: VercelRequest): string | null {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string') return forwarded.split(',')[0]?.trim() || null;
+  if (Array.isArray(forwarded)) return forwarded[0]?.split(',')[0]?.trim() || null;
+  return req.socket?.remoteAddress || null;
+}
+
+export async function recordAuditEvent(req: VercelRequest, event: AuditEvent): Promise<void> {
+  const token = auditToken();
+  if (!token) {
+    console.warn(`[audit] skipped ${event.action}: Q12 audit token not configured`);
+    return;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), AUDIT_TIMEOUT_MS);
+  const now = new Date().toISOString();
+  const payload = {
+    id: randomUUID(),
+    product: 'nmf-curator-studio',
+    source: 'vercel-function',
+    action: event.action,
+    outcome: event.outcome,
+    status: event.status ?? null,
+    route: requestPath(req),
+    method: req.method,
+    actor_hash: hashActor(event.actor),
+    client_ip_hash: hashActor(clientIp(req)),
+    user_agent: req.headers['user-agent'] || null,
+    metadata: event.metadata || {},
+    occurred_at: now,
+  };
+
+  try {
+    const resp = await fetch(auditEndpoint(), {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      console.warn(`[audit] ${event.action} sink returned ${resp.status}`);
+    }
+  } catch (e) {
+    console.warn(`[audit] ${event.action} sink failed:`, e instanceof Error ? e.message : String(e));
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/api/cron-claim-review.ts
+++ b/api/cron-claim-review.ts
@@ -1,5 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { runWeeklyReview } from '../scripts/claim-weekly-alpha-handoff.js';
+import { recordAuditEvent } from './_audit.js';
 
 /**
  * GET /api/cron-claim-review
@@ -20,12 +21,23 @@ const CRON_SECRET = process.env.CRON_SECRET || '';
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET' && req.method !== 'POST') {
     res.setHeader('Allow', 'GET, POST');
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.claim_review',
+      outcome: 'skipped',
+      status: 405,
+      metadata: { reason: 'method_not_allowed' },
+    });
     return res.status(405).json({ error: 'GET/POST only' });
   }
   // Vercel cron sends `Authorization: Bearer ${CRON_SECRET}` when configured.
   if (CRON_SECRET) {
     const auth = req.headers.authorization || '';
     if (auth !== `Bearer ${CRON_SECRET}`) {
+      await recordAuditEvent(req, {
+        action: 'nmf.cron.claim_review',
+        outcome: 'unauthorized',
+        status: 401,
+      });
       return res.status(401).json({ error: 'Unauthorized' });
     }
   }
@@ -35,9 +47,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   try {
     const result = await runWeeklyReview();
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.claim_review',
+      outcome: result.ok ? 'success' : 'failure',
+      status: result.ok ? 200 : 500,
+      metadata: { ok: result.ok },
+    });
     return res.status(result.ok ? 200 : 500).json(result);
   } catch (e) {
     console.error('[cron-claim-review] exception:', e);
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.claim_review',
+      outcome: 'failure',
+      status: 500,
+      metadata: { reason: 'exception' },
+    });
     return res.status(500).json({
       ok: false,
       error: e instanceof Error ? e.message : 'unknown',

--- a/api/cron-scan-daily.ts
+++ b/api/cron-scan-daily.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { IntelligenceAccumulator, emitIntelligence, extractComposerCandidates, splitPerformerCreditString, type CollaborationSignal, type AppleRejection } from './_scan_intelligence.js';
 import { runHealthProbe } from './scan-health.js';
 import { alertSlack } from './_alert.js';
+import { recordAuditEvent } from './_audit.js';
 
 // Daily Apple-only fresh-release scan (M-Z12).
 // Target window: the last 48h of releases. Paired with the weekly full-universe
@@ -77,14 +78,31 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const CRON_SECRET = process.env.CRON_SECRET;
   if (!CRON_SECRET) {
     console.error('[DAILY] CRON_SECRET not configured — refusing to run');
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.daily_scan',
+      outcome: 'skipped',
+      status: 500,
+      metadata: { reason: 'cron_secret_missing' },
+    });
     return res.status(500).json({ error: 'Server misconfigured' });
   }
   const authHeader = req.headers.authorization;
   if (authHeader !== `Bearer ${CRON_SECRET}`) {
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.daily_scan',
+      outcome: 'unauthorized',
+      status: 401,
+    });
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
   if (!SUPABASE_URL || !SUPABASE_KEY) {
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.daily_scan',
+      outcome: 'skipped',
+      status: 500,
+      metadata: { reason: 'supabase_config_missing' },
+    });
     return res.status(500).json({ error: 'Server misconfigured' });
   }
   const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
@@ -105,10 +123,27 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           apple_error: health.apple.error,
           retry_after_s: health.apple.retry_after_seconds,
         }).catch(() => {});
+        await recordAuditEvent(req, {
+          action: 'nmf.cron.daily_scan',
+          outcome: 'failure',
+          status: 503,
+          metadata: {
+            scan_date: scanDate,
+            chain: chainNum,
+            reason: 'preflight_aborted',
+            apple_status: health.apple.status,
+          },
+        });
         return res.status(503).json({ status: 'preflight_aborted', apple: health.apple });
       }
     } catch (e) {
       console.error('[DAILY] Pre-flight threw:', e);
+      await recordAuditEvent(req, {
+        action: 'nmf.cron.daily_scan',
+        outcome: 'failure',
+        status: 500,
+        metadata: { scan_date: scanDate, chain: chainNum, reason: 'preflight_error' },
+      });
       return res.status(500).json({ status: 'preflight_error', error: (e as Error).message });
     }
   }
@@ -320,6 +355,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   } catch (e) {
     console.error('[DAILY] scan_intelligence emit threw:', e);
   }
+
+  await recordAuditEvent(req, {
+    action: 'nmf.cron.daily_scan',
+    outcome: 'success',
+    status: 200,
+    metadata: {
+      scan_date: scanDate,
+      chain: chainNum,
+      max_chains: maxChains,
+      artists_scanned: batch.length,
+      apple_tracks: appleTracks,
+      failed_batches: failedBatches,
+      status: chainStatus,
+    },
+  });
 
   return res.status(200).json({
     status: chainStatus,

--- a/api/cron-scan-weekly.ts
+++ b/api/cron-scan-weekly.ts
@@ -2,6 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { IntelligenceAccumulator, emitIntelligence, extractComposerCandidates, splitPerformerCreditString, type CollaborationSignal, type AppleRejection } from './_scan_intelligence.js';
 import { runHealthProbe } from './scan-health.js';
+import { recordAuditEvent } from './_audit.js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
@@ -53,15 +54,32 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const CRON_SECRET = process.env.CRON_SECRET;
   if (!CRON_SECRET) {
     console.error('[CRON] CRON_SECRET not configured — refusing to run');
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.weekly_scan',
+      outcome: 'skipped',
+      status: 500,
+      metadata: { reason: 'cron_secret_missing' },
+    });
     return res.status(500).json({ error: 'Server misconfigured' });
   }
   const authHeader = req.headers.authorization;
   if (authHeader !== `Bearer ${CRON_SECRET}`) {
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.weekly_scan',
+      outcome: 'unauthorized',
+      status: 401,
+    });
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
   if (!SUPABASE_URL || !SUPABASE_KEY) {
     console.error('[CRON] SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not configured');
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.weekly_scan',
+      outcome: 'skipped',
+      status: 500,
+      metadata: { reason: 'supabase_config_missing' },
+    });
     return res.status(500).json({ error: 'Server misconfigured' });
   }
   const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
@@ -94,6 +112,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           last_scan_at: new Date().toISOString(),
           status: 'preflight_aborted',
         });
+        await recordAuditEvent(req, {
+          action: 'nmf.cron.weekly_scan',
+          outcome: 'failure',
+          status: 503,
+          metadata: {
+            week: weekDate,
+            chain: chainNum,
+            reason: 'preflight_aborted',
+            spotify_ok: health.spotify_ok,
+            apple_ok: health.apple_ok,
+          },
+        });
         return res.status(503).json({
           status: 'preflight_aborted',
           reason: `spotify_ok=${health.spotify_ok} apple_ok=${health.apple_ok}`,
@@ -103,6 +133,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       console.log(`[CRON] Pre-flight OK: spotify=${health.spotify.latency_ms}ms apple=${health.apple.latency_ms}ms`);
     } catch (e) {
       console.error('[CRON] Pre-flight threw:', e);
+      await recordAuditEvent(req, {
+        action: 'nmf.cron.weekly_scan',
+        outcome: 'failure',
+        status: 500,
+        metadata: { week: weekDate, chain: chainNum, reason: 'preflight_error' },
+      });
       return res.status(500).json({ status: 'preflight_error', error: (e as Error).message });
     }
   } else if (skipPreflight && chainNum === 0) {
@@ -596,6 +632,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   } catch (e) {
     console.error('[CRON] scan_intelligence build/emit threw:', e);
   }
+
+  await recordAuditEvent(req, {
+    action: 'nmf.cron.weekly_scan',
+    outcome: 'success',
+    status: 200,
+    metadata: {
+      week: weekDate,
+      chain: chainNum,
+      max_chains: maxChains,
+      artists_scanned: scanned,
+      tracks_found: totalTracks,
+      status: chainStatus,
+    },
+  });
 
   return res.status(200).json({
     status: chainStatus,

--- a/api/postflight.ts
+++ b/api/postflight.ts
@@ -16,6 +16,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { alertSlack } from './_alert.js';
+import { recordAuditEvent } from './_audit.js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
@@ -33,11 +34,32 @@ function getLastFriday(): string {
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const CRON_SECRET = process.env.CRON_SECRET;
-  if (!CRON_SECRET) return res.status(500).json({ error: 'CRON_SECRET not configured' });
+  if (!CRON_SECRET) {
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.postflight',
+      outcome: 'skipped',
+      status: 500,
+      metadata: { reason: 'cron_secret_missing' },
+    });
+    return res.status(500).json({ error: 'CRON_SECRET not configured' });
+  }
   if (req.headers.authorization !== `Bearer ${CRON_SECRET}`) {
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.postflight',
+      outcome: 'unauthorized',
+      status: 401,
+    });
     return res.status(401).json({ error: 'Unauthorized' });
   }
-  if (!SUPABASE_URL || !SUPABASE_KEY) return res.status(500).json({ error: 'Supabase not configured' });
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.postflight',
+      outcome: 'skipped',
+      status: 500,
+      metadata: { reason: 'supabase_config_missing' },
+    });
+    return res.status(500).json({ error: 'Supabase not configured' });
+  }
   const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
   const weekDate = (req.query.week as string) || getLastFriday();
@@ -97,7 +119,24 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   if (failures.length > 0) {
     await alertSlack(`NMF Post-flight FAILED for ${weekDate}`, report).catch(() => {});
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.postflight',
+      outcome: 'failure',
+      status: 503,
+      metadata: {
+        week: weekDate,
+        release_count: releaseCount,
+        intel_rows: intelCount,
+        failure_checks: failures.map(f => f.check),
+      },
+    });
     return res.status(503).json(report);
   }
+  await recordAuditEvent(req, {
+    action: 'nmf.cron.postflight',
+    outcome: 'success',
+    status: 200,
+    metadata: { week: weekDate, release_count: releaseCount, intel_rows: intelCount },
+  });
   return res.status(200).json(report);
 }

--- a/api/preflight.ts
+++ b/api/preflight.ts
@@ -18,6 +18,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { runHealthProbe } from './scan-health.js';
 import { alertSlack } from './_alert.js';
+import { recordAuditEvent } from './_audit.js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
@@ -40,11 +41,32 @@ async function generateNdApiToken(): Promise<string> {
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const CRON_SECRET = process.env.CRON_SECRET;
-  if (!CRON_SECRET) return res.status(500).json({ error: 'CRON_SECRET not configured' });
+  if (!CRON_SECRET) {
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.preflight',
+      outcome: 'skipped',
+      status: 500,
+      metadata: { reason: 'cron_secret_missing' },
+    });
+    return res.status(500).json({ error: 'CRON_SECRET not configured' });
+  }
   if (req.headers.authorization !== `Bearer ${CRON_SECRET}`) {
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.preflight',
+      outcome: 'unauthorized',
+      status: 401,
+    });
     return res.status(401).json({ error: 'Unauthorized' });
   }
-  if (!SUPABASE_URL || !SUPABASE_KEY) return res.status(500).json({ error: 'Supabase not configured' });
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.preflight',
+      outcome: 'skipped',
+      status: 500,
+      metadata: { reason: 'supabase_config_missing' },
+    });
+    return res.status(500).json({ error: 'Supabase not configured' });
+  }
   const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
   const failures: Array<{ check: string; detail: unknown }> = [];
@@ -121,7 +143,24 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   if (failures.length > 0) {
     await alertSlack('NMF Pre-flight FAILED', report).catch(() => {});
+    await recordAuditEvent(req, {
+      action: 'nmf.cron.preflight',
+      outcome: 'failure',
+      status: 503,
+      metadata: {
+        duration_ms,
+        universe_size: universeSize,
+        apple_cached: appleCached,
+        failure_checks: failures.map(f => f.check),
+      },
+    });
     return res.status(503).json(report);
   }
+  await recordAuditEvent(req, {
+    action: 'nmf.cron.preflight',
+    outcome: 'success',
+    status: 200,
+    metadata: { duration_ms, universe_size: universeSize, apple_cached: appleCached },
+  });
   return res.status(200).json(report);
 }


### PR DESCRIPTION
## Summary
- add a shared NMF Vercel audit forwarder for Q12 product-side events
- emit sanitized audit events from weekly/daily scan crons, preflight, postflight, and claim-review cron
- forward to `Q12_AUDIT_ENDPOINT_URL` / `WORKERS_AUDIT_ENDPOINT_URL`, defaulting to the nd-api Worker audit route; fail-open when the sink token is not configured

## Verification
- `npm run build` PASS
- `npx eslint api/_audit.ts api/preflight.ts api/postflight.ts api/cron-claim-review.ts` PASS
- `git diff --check` PASS

Note: `npx eslint api/_audit.ts api/cron-scan-weekly.ts api/cron-scan-daily.ts api/preflight.ts api/postflight.ts api/cron-claim-review.ts` is blocked by pre-existing `no-explicit-any` errors in `cron-scan-weekly.ts` and `cron-scan-daily.ts`; the full repo lint baseline is already red.

[pre-ack-request] Q12 NMF Vercel Function audit forwarding · product-side half of Path B · awaits Worker sink coordination
