### PR TITLE
[CODEX-D] NMF Phase 6 scaffold · v2 Marquee body templates

### DIFF
--- a/src/lib/body-templates-v2-phase6.ts
+++ b/src/lib/body-templates-v2-phase6.ts
@@ -1,0 +1,118 @@
+import { PHASE3_LIVE_BODY_TEMPLATE_PRESETS } from './body-templates-v2-phase3';
+import { NMF_BRAND_TOKENS, V2_PALETTES } from './brand-tokens';
+import type { V2CarouselBodyTemplate } from './template-types-v2';
+
+export type Phase6MarqueeBodyBand = 'marquee-rev2-core' | 'marquee-rev2-range';
+
+export interface Phase6MarqueeBodyTemplateScaffold {
+  band: Phase6MarqueeBodyBand;
+  template: V2CarouselBodyTemplate;
+  marqueeRevision: 'rev-2';
+  liveInPhase6: true;
+}
+
+const serifFonts = {
+  display: NMF_BRAND_TOKENS.font.display,
+  body: NMF_BRAND_TOKENS.font.body,
+  mono: NMF_BRAND_TOKENS.font.mono,
+};
+
+const sansFonts = {
+  display: NMF_BRAND_TOKENS.font.sans,
+  body: NMF_BRAND_TOKENS.font.sans,
+  mono: NMF_BRAND_TOKENS.font.mono,
+};
+
+const marqueeGoldRoom: V2CarouselBodyTemplate = {
+  id: 'v2_marquee_gold_room',
+  name: 'Marquee Gold Room',
+  description: 'Deep theater body grid with gold bulbs, teal logo block, and editorial covers',
+  engine: 'v2',
+  kind: 'body',
+  palette: {
+    bg: NMF_BRAND_TOKENS.color.inkPrimary,
+    accent: NMF_BRAND_TOKENS.color.accentGold,
+    accent2: NMF_BRAND_TOKENS.color.accentTeal,
+    text: NMF_BRAND_TOKENS.color.ivory,
+    textMuted: NMF_BRAND_TOKENS.color.warmGold,
+  },
+  fonts: serifFonts,
+  cellPadding: 13,
+  cellRadius: 5,
+  cellShadow: '0 16px 34px rgba(0,0,0,.5)',
+  cellRotate: [-0.9, 0.7, -0.5, 0.9, -0.7, 0.5, -1.1, 0.8, -0.4],
+  decoration: 'marquee-bulbs',
+  showGrain: true,
+  grainOpacity: 0.045,
+};
+
+const marqueeNeonBackline: V2CarouselBodyTemplate = {
+  id: 'v2_marquee_neon_backline',
+  name: 'Marquee Neon Backline',
+  description: 'Black-box show grid with teal glow and warm marquee edges',
+  engine: 'v2',
+  kind: 'body',
+  palette: {
+    bg: NMF_BRAND_TOKENS.color.inkPrimary,
+    accent: NMF_BRAND_TOKENS.color.accentTeal,
+    accent2: NMF_BRAND_TOKENS.color.accentGold,
+    text: NMF_BRAND_TOKENS.color.paper,
+    textMuted: NMF_BRAND_TOKENS.color.accentTeal,
+  },
+  fonts: sansFonts,
+  cellPadding: 11,
+  cellRadius: 2,
+  cellShadow: '0 0 32px rgba(62,230,195,.24)',
+  cellRotate: [0, 0.25, -0.25, 0, 0.2, -0.2, 0, 0.15, -0.15],
+  decoration: 'marquee-bulbs',
+  neonGlow: { color: NMF_BRAND_TOKENS.color.accentTeal, size: 14, intensity: 0.75 },
+  showGrain: true,
+  grainOpacity: 0.035,
+  postProcess: 'scanlines',
+};
+
+const marqueePosterStack: V2CarouselBodyTemplate = {
+  id: 'v2_marquee_poster_stack',
+  name: 'Marquee Poster Stack',
+  description: 'Warm poster-wall treatment for dense weeks and release roundups',
+  engine: 'v2',
+  kind: 'body',
+  palette: {
+    ...V2_PALETTES.honkyTonk,
+    accent: NMF_BRAND_TOKENS.color.rust,
+    accent2: NMF_BRAND_TOKENS.color.accentGold,
+  },
+  fonts: serifFonts,
+  cellPadding: 9,
+  cellRadius: 1,
+  cellShadow: '5px 5px 0 rgba(26,22,16,.72)',
+  cellRotate: [-1.4, 1.1, -0.8, 1.3, -1, 0.8, -1.2, 1, -0.7],
+  decoration: 'halftone-banner',
+  showGrain: true,
+  grainOpacity: 0.05,
+  postProcess: 'halftone',
+};
+
+function marquee(
+  band: Phase6MarqueeBodyBand,
+  template: V2CarouselBodyTemplate,
+): Phase6MarqueeBodyTemplateScaffold {
+  return { band, template, marqueeRevision: 'rev-2', liveInPhase6: true };
+}
+
+export const PHASE6_MARQUEE_BODY_TEMPLATE_SCAFFOLD: Phase6MarqueeBodyTemplateScaffold[] = [
+  marquee('marquee-rev2-core', marqueeGoldRoom),
+  marquee('marquee-rev2-core', marqueeNeonBackline),
+  marquee('marquee-rev2-range', marqueePosterStack),
+];
+
+export const PHASE6_MARQUEE_BODY_TEMPLATE_IDS = PHASE6_MARQUEE_BODY_TEMPLATE_SCAFFOLD
+  .map(item => item.template.id);
+
+export const PHASE6_MARQUEE_BODY_TEMPLATE_PRESETS = PHASE6_MARQUEE_BODY_TEMPLATE_SCAFFOLD
+  .map(item => item.template);
+
+export const PHASE6_LIVE_BODY_TEMPLATE_PRESETS: V2CarouselBodyTemplate[] = [
+  ...PHASE3_LIVE_BODY_TEMPLATE_PRESETS,
+  ...PHASE6_MARQUEE_BODY_TEMPLATE_PRESETS,
+];

--- a/src/lib/carousel-templates.ts
+++ b/src/lib/carousel-templates.ts
@@ -1,4 +1,4 @@
-import { PHASE3_LIVE_BODY_TEMPLATE_PRESETS } from './body-templates-v2-phase3';
+import { PHASE6_LIVE_BODY_TEMPLATE_PRESETS } from './body-templates-v2-phase6';
 import type { TemplateEngine, V2CarouselBodyTemplate } from './template-types-v2';
 
 export interface CarouselTemplate {
@@ -435,10 +435,10 @@ const V1_TEMPLATES: CarouselTemplate[] = LEGACY_TEMPLATES.map(template => ({
 
 export const TEMPLATES: CarouselTemplate[] = [
   ...V1_TEMPLATES,
-  ...PHASE3_LIVE_BODY_TEMPLATE_PRESETS.map(carouselShellFromV2),
+  ...PHASE6_LIVE_BODY_TEMPLATE_PRESETS.map(carouselShellFromV2),
 ];
 
-const V2_BODY_TEMPLATE_PRESET_BY_ID = new Map(PHASE3_LIVE_BODY_TEMPLATE_PRESETS.map(template => [template.id, template]));
+const V2_BODY_TEMPLATE_PRESET_BY_ID = new Map(PHASE6_LIVE_BODY_TEMPLATE_PRESETS.map(template => [template.id, template]));
 
 /** Templates that are exclusive to Max's account */
 export const MAX_ONLY_TEMPLATES = new Set(['mmmc_classic', 'neon_rose', 'golden_hour']);

--- a/tests/unit/canvas-renderer-v2.test.ts
+++ b/tests/unit/canvas-renderer-v2.test.ts
@@ -37,6 +37,11 @@ import {
   PHASE5_CLOSING_TEMPLATE_PRESET,
   PHASE5_CLOSING_TEMPLATE_SCAFFOLD,
 } from '../../src/lib/closing-template-v2-phase5';
+import {
+  PHASE6_LIVE_BODY_TEMPLATE_PRESETS,
+  PHASE6_MARQUEE_BODY_TEMPLATE_IDS,
+  PHASE6_MARQUEE_BODY_TEMPLATE_SCAFFOLD,
+} from '../../src/lib/body-templates-v2-phase6';
 
 describe('canvas renderer v2 phase 1 surface', () => {
   it('normalizes design zip dash IDs to production-safe underscore IDs', () => {
@@ -162,5 +167,22 @@ describe('canvas renderer v2 phase 1 surface', () => {
       'share-reminder',
       'next-friday-return',
     ]);
+  });
+
+  it('ships Phase 6 Marquee body templates rev 2 through the carousel registry', () => {
+    expect(PHASE6_MARQUEE_BODY_TEMPLATE_IDS).toEqual([
+      'v2_marquee_gold_room',
+      'v2_marquee_neon_backline',
+      'v2_marquee_poster_stack',
+    ]);
+    expect(PHASE6_MARQUEE_BODY_TEMPLATE_SCAFFOLD.every(item => item.marqueeRevision === 'rev-2')).toBe(true);
+    expect(PHASE6_MARQUEE_BODY_TEMPLATE_SCAFFOLD.every(item => item.liveInPhase6)).toBe(true);
+    expect(PHASE6_LIVE_BODY_TEMPLATE_PRESETS).toHaveLength(
+      PHASE3_LIVE_BODY_TEMPLATE_PRESETS.length + PHASE6_MARQUEE_BODY_TEMPLATE_IDS.length,
+    );
+    expect(getVisibleTemplates('curator@example.com').map(template => template.id)).toEqual(
+      expect.arrayContaining(PHASE6_MARQUEE_BODY_TEMPLATE_IDS),
+    );
+    expect(getV2BodyTemplatePreset(getTemplate('v2_marquee_gold_room'))?.decoration).toBe('marquee-bulbs');
   });
 });


### PR DESCRIPTION
## Summary
- Adds Phase 6 Marquee body template scaffold with 3 rev-2 v2 body presets.
- Expands the active v2 carousel registry from Phase 3 live presets to Phase 6 live presets.
- Adds unit coverage proving Phase 6 IDs are live, visible, and mapped back to v2 renderer presets.

## Validation
- `npm test -- tests/unit/canvas-renderer-v2.test.ts`
- `npm run build`

## Stack
- Base: `codex-d/nmf-phase4-phase5-template-scaffold`
- Continues the NMF Phase 2-5 v2 template stack without modifying v1 templates.
