### PR TITLE
[CODEX-A] NMF U1 umbrella rename

### DIFF
--- a/tests/unit/vercel-redirects.test.ts
+++ b/tests/unit/vercel-redirects.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+interface VercelRedirect {
+  source: string;
+  destination: string;
+  statusCode?: number;
+  has?: Array<{
+    type: string;
+    value: string;
+  }>;
+}
+
+const config = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'vercel.json'), 'utf8')
+) as { redirects: VercelRedirect[] };
+
+describe('Vercel redirect routing', () => {
+  it('redirects the MMMC umbrella host to the canonical NMF domain before SPA rewrites', () => {
+    const [umbrellaRedirect] = config.redirects;
+
+    expect(umbrellaRedirect).toEqual({
+      source: '/:path*',
+      has: [{ type: 'host', value: 'maxmeetsmusiccity.com' }],
+      destination: 'https://newmusicfriday.app/:path*',
+      statusCode: 308,
+    });
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "maxmeetsmusiccity.com" }],
+      "destination": "https://newmusicfriday.app/:path*",
+      "statusCode": 308
+    },
     { "source": "/nmf", "destination": "/newmusicfriday", "statusCode": 301 },
     { "source": "/nmf/:path*", "destination": "/newmusicfriday/:path*", "statusCode": 301 }
   ],


### PR DESCRIPTION
## Summary
- adds a host-scoped 308 redirect from maxmeetsmusiccity.com/* to newmusicfriday.app/*
- keeps existing /nmf -> /newmusicfriday redirects for the canonical NMF host
- adds a unit guard so the umbrella host redirect stays first in vercel.json before SPA rewrites

## Context
Design visual coherence audit flagged U1 as an NMF leak on the MMMC umbrella domain. This PR implements the BB v3 §2.1 expectation that maxmeetsmusiccity.com/* redirects to newmusicfriday.app/*.

## Validation
- npm test -- vercel-redirects
- npm test
- npm run build
- git diff --check

[pre-ack-request] Codex-A NMF U1 umbrella rename for Design pass