### PR TITLE
[CODEX-D] NMF Phase 7 · curator template enrichment

### DIFF
--- a/src/lib/body-templates-v2-phase7.ts
+++ b/src/lib/body-templates-v2-phase7.ts
@@ -1,0 +1,138 @@
+import { PHASE6_LIVE_BODY_TEMPLATE_PRESETS } from './body-templates-v2-phase6';
+import { NMF_BRAND_TOKENS, V2_PALETTES } from './brand-tokens';
+import type { V2CarouselBodyTemplate } from './template-types-v2';
+
+export type Phase7CuratorTemplateMoment =
+  | 'artist-discovery'
+  | 'playlist-pitch'
+  | 'songwriter-credit'
+  | 'weekly-recap';
+
+export interface Phase7CuratorBodyTemplateScaffold {
+  moment: Phase7CuratorTemplateMoment;
+  template: V2CarouselBodyTemplate;
+  curatorEnrichment: 'phase-7';
+  recommendedTrackCounts: readonly number[];
+  liveInPhase7: true;
+}
+
+const serifFonts = {
+  display: NMF_BRAND_TOKENS.font.display,
+  body: NMF_BRAND_TOKENS.font.body,
+  mono: NMF_BRAND_TOKENS.font.mono,
+};
+
+const sansFonts = {
+  display: NMF_BRAND_TOKENS.font.sans,
+  body: NMF_BRAND_TOKENS.font.sans,
+  mono: NMF_BRAND_TOKENS.font.mono,
+};
+
+const scriptFonts = {
+  ...serifFonts,
+  script: NMF_BRAND_TOKENS.font.script,
+};
+
+const curatorSpotlight: V2CarouselBodyTemplate = {
+  id: 'v2_curator_spotlight',
+  name: 'Curator Spotlight',
+  description: 'Feature-forward wall for curator notes and first-listen picks',
+  engine: 'v2',
+  kind: 'body',
+  palette: {
+    bg: NMF_BRAND_TOKENS.color.inkPrimary,
+    accent: NMF_BRAND_TOKENS.color.accentTeal,
+    accent2: NMF_BRAND_TOKENS.color.accentGold,
+    text: NMF_BRAND_TOKENS.color.paper,
+    textMuted: NMF_BRAND_TOKENS.color.ivory,
+  },
+  fonts: sansFonts,
+  cellPadding: 12,
+  cellRadius: 4,
+  cellRotate: [-0.7, 0.4, -0.2, 0.6, -0.4, 0.2, -0.6, 0.5, 0],
+  decoration: 'spotlight',
+  showGrain: true,
+  grainOpacity: 0.035,
+  postProcess: 'spotlight',
+};
+
+const pitchRoom: V2CarouselBodyTemplate = {
+  id: 'v2_pitch_room',
+  name: 'Pitch Room',
+  description: 'Label-pitch grid with clean hierarchy for playlist placements',
+  engine: 'v2',
+  kind: 'body',
+  palette: V2_PALETTES.mmmcClassic,
+  fonts: serifFonts,
+  cellPadding: 15,
+  cellRadius: 3,
+  cellRotate: [-0.4, 0.3, -0.2, 0.4, -0.3, 0.2, -0.5, 0.4, -0.1],
+  decoration: 'gold-frame',
+  showGrain: true,
+  grainOpacity: 0.03,
+};
+
+const writerBoard: V2CarouselBodyTemplate = {
+  id: 'v2_writer_board',
+  name: 'Writer Board',
+  description: 'Songwriter-credit proof sheet with editorial ivory spacing',
+  engine: 'v2',
+  kind: 'body',
+  palette: V2_PALETTES.pearlSnap,
+  fonts: scriptFonts,
+  cellPadding: 14,
+  cellRadius: 2,
+  cellRotate: [-0.5, 0.5, -0.3, 0.3, -0.2, 0.2, -0.4, 0.4, 0],
+  decoration: 'script-flourish',
+  showGrain: true,
+  grainOpacity: 0.025,
+};
+
+const recapWall: V2CarouselBodyTemplate = {
+  id: 'v2_recap_wall',
+  name: 'Recap Wall',
+  description: 'Dense week-in-review grid for larger Friday release slates',
+  engine: 'v2',
+  kind: 'body',
+  palette: V2_PALETTES.honkyTonk,
+  fonts: serifFonts,
+  cellPadding: 9,
+  cellRadius: 1,
+  cellRotate: [-1.2, 0.9, -0.7, 1, -0.8, 0.6, -1, 0.8, -0.5],
+  decoration: 'halftone-banner',
+  showGrain: true,
+  grainOpacity: 0.05,
+  postProcess: 'halftone',
+};
+
+function curator(
+  moment: Phase7CuratorTemplateMoment,
+  template: V2CarouselBodyTemplate,
+  recommendedTrackCounts: readonly number[],
+): Phase7CuratorBodyTemplateScaffold {
+  return {
+    moment,
+    template,
+    curatorEnrichment: 'phase-7',
+    recommendedTrackCounts,
+    liveInPhase7: true,
+  };
+}
+
+export const PHASE7_CURATOR_BODY_TEMPLATE_SCAFFOLD: Phase7CuratorBodyTemplateScaffold[] = [
+  curator('artist-discovery', curatorSpotlight, [4, 6, 8]),
+  curator('playlist-pitch', pitchRoom, [6, 9]),
+  curator('songwriter-credit', writerBoard, [4, 6]),
+  curator('weekly-recap', recapWall, [9, 12]),
+];
+
+export const PHASE7_CURATOR_BODY_TEMPLATE_IDS = PHASE7_CURATOR_BODY_TEMPLATE_SCAFFOLD
+  .map(item => item.template.id);
+
+export const PHASE7_CURATOR_BODY_TEMPLATE_PRESETS = PHASE7_CURATOR_BODY_TEMPLATE_SCAFFOLD
+  .map(item => item.template);
+
+export const PHASE7_LIVE_BODY_TEMPLATE_PRESETS: V2CarouselBodyTemplate[] = [
+  ...PHASE6_LIVE_BODY_TEMPLATE_PRESETS,
+  ...PHASE7_CURATOR_BODY_TEMPLATE_PRESETS,
+];

--- a/src/lib/carousel-templates.ts
+++ b/src/lib/carousel-templates.ts
@@ -1,4 +1,4 @@
-import { PHASE6_LIVE_BODY_TEMPLATE_PRESETS } from './body-templates-v2-phase6';
+import { PHASE7_LIVE_BODY_TEMPLATE_PRESETS } from './body-templates-v2-phase7';
 import type { TemplateEngine, V2CarouselBodyTemplate } from './template-types-v2';
 
 export interface CarouselTemplate {
@@ -435,10 +435,10 @@ const V1_TEMPLATES: CarouselTemplate[] = LEGACY_TEMPLATES.map(template => ({
 
 export const TEMPLATES: CarouselTemplate[] = [
   ...V1_TEMPLATES,
-  ...PHASE6_LIVE_BODY_TEMPLATE_PRESETS.map(carouselShellFromV2),
+  ...PHASE7_LIVE_BODY_TEMPLATE_PRESETS.map(carouselShellFromV2),
 ];
 
-const V2_BODY_TEMPLATE_PRESET_BY_ID = new Map(PHASE6_LIVE_BODY_TEMPLATE_PRESETS.map(template => [template.id, template]));
+const V2_BODY_TEMPLATE_PRESET_BY_ID = new Map(PHASE7_LIVE_BODY_TEMPLATE_PRESETS.map(template => [template.id, template]));
 
 /** Templates that are exclusive to Max's account */
 export const MAX_ONLY_TEMPLATES = new Set(['mmmc_classic', 'neon_rose', 'golden_hour']);

--- a/tests/unit/canvas-renderer-v2.test.ts
+++ b/tests/unit/canvas-renderer-v2.test.ts
@@ -42,6 +42,11 @@ import {
   PHASE6_MARQUEE_BODY_TEMPLATE_IDS,
   PHASE6_MARQUEE_BODY_TEMPLATE_SCAFFOLD,
 } from '../../src/lib/body-templates-v2-phase6';
+import {
+  PHASE7_CURATOR_BODY_TEMPLATE_IDS,
+  PHASE7_CURATOR_BODY_TEMPLATE_SCAFFOLD,
+  PHASE7_LIVE_BODY_TEMPLATE_PRESETS,
+} from '../../src/lib/body-templates-v2-phase7';
 
 describe('canvas renderer v2 phase 1 surface', () => {
   it('normalizes design zip dash IDs to production-safe underscore IDs', () => {
@@ -184,5 +189,24 @@ describe('canvas renderer v2 phase 1 surface', () => {
       expect.arrayContaining(PHASE6_MARQUEE_BODY_TEMPLATE_IDS),
     );
     expect(getV2BodyTemplatePreset(getTemplate('v2_marquee_gold_room'))?.decoration).toBe('marquee-bulbs');
+  });
+
+  it('ships Phase 7 curator-enrichment body templates through the carousel registry', () => {
+    expect(PHASE7_CURATOR_BODY_TEMPLATE_IDS).toEqual([
+      'v2_curator_spotlight',
+      'v2_pitch_room',
+      'v2_writer_board',
+      'v2_recap_wall',
+    ]);
+    expect(PHASE7_CURATOR_BODY_TEMPLATE_SCAFFOLD.every(item => item.curatorEnrichment === 'phase-7')).toBe(true);
+    expect(PHASE7_CURATOR_BODY_TEMPLATE_SCAFFOLD.every(item => item.liveInPhase7)).toBe(true);
+    expect(PHASE7_CURATOR_BODY_TEMPLATE_SCAFFOLD.every(item => item.recommendedTrackCounts.length > 0)).toBe(true);
+    expect(PHASE7_LIVE_BODY_TEMPLATE_PRESETS).toHaveLength(
+      PHASE6_LIVE_BODY_TEMPLATE_PRESETS.length + PHASE7_CURATOR_BODY_TEMPLATE_IDS.length,
+    );
+    expect(getVisibleTemplates('curator@example.com').map(template => template.id)).toEqual(
+      expect.arrayContaining(PHASE7_CURATOR_BODY_TEMPLATE_IDS),
+    );
+    expect(getV2BodyTemplatePreset(getTemplate('v2_writer_board'))?.fonts.script).toBe(NMF_BRAND_TOKENS.font.script);
   });
 });


### PR DESCRIPTION
Builds on merged Phase 6 / PR #36 (`6df81d980e02f3b61010426bd6240b969c4a4fa2`).

[pre-ack-request] Strategy ratify-go in Wave 8 continuation. Scope: NMF Phase 7 curator template enrichment.

Changes:
- Adds `body-templates-v2-phase7.ts` with four curator-enrichment v2 body templates.
- Wires the carousel registry to the Phase 7 live body preset list.
- Extends unit coverage for Phase 7 IDs, live flags, curator metadata, recommended track counts, registry visibility, and token-font routing.

Verification:
- `rg -n "#[0-9A-Fa-f]{3,8}|rgba?\(" src/lib/body-templates-v2-phase7.ts` -> no matches
- `git diff -U0 -- src/lib/body-templates-v2-phase7.ts src/lib/carousel-templates.ts tests/unit/canvas-renderer-v2.test.ts | rg -n "^\+.*(#[0-9A-Fa-f]{3,8}|rgba?\()"` -> no matches
- `npm test -- --run tests/unit/canvas-renderer-v2.test.ts` -> 1 file passed, 16 tests passed
- `npm test` -> 41 files passed, 534 tests passed
- `npm run build` -> pass
- `git diff --check` -> pass
