### PR TITLE
[CODEX-D] NMF Phase 8 · template pairing scaffold

### DIFF
--- a/src/lib/template-pairings-v2-phase8.ts
+++ b/src/lib/template-pairings-v2-phase8.ts
@@ -1,0 +1,80 @@
+import { PHASE7_CURATOR_BODY_TEMPLATE_IDS } from './body-templates-v2-phase7';
+import { PHASE5_CLOSING_TEMPLATE_PRESET } from './closing-template-v2-phase5';
+import { PHASE4_TITLE_TEMPLATE_IDS } from './title-templates-v2-phase4';
+
+export type Phase8CuratorJourney =
+  | 'discovery-stack'
+  | 'playlist-pitch'
+  | 'writer-credit'
+  | 'weekly-recap';
+
+export interface Phase8TemplatePairingScaffold {
+  id: string;
+  journey: Phase8CuratorJourney;
+  titleTemplateId: string;
+  bodyTemplateId: string;
+  closingTemplateId: string;
+  editorialCue: string;
+  liveInPhase8: false;
+  readyForPhase8Activation: true;
+}
+
+function pairing(
+  journey: Phase8CuratorJourney,
+  titleTemplateId: string,
+  bodyTemplateId: string,
+  editorialCue: string,
+): Phase8TemplatePairingScaffold {
+  return {
+    id: `phase8_${journey}`,
+    journey,
+    titleTemplateId,
+    bodyTemplateId,
+    closingTemplateId: PHASE5_CLOSING_TEMPLATE_PRESET.id,
+    editorialCue,
+    liveInPhase8: false,
+    readyForPhase8Activation: true,
+  };
+}
+
+export const PHASE8_TEMPLATE_PAIRING_SCAFFOLD: Phase8TemplatePairingScaffold[] = [
+  pairing(
+    'discovery-stack',
+    'v2_script_spotlight',
+    'v2_curator_spotlight',
+    'Lead with the curator reason to listen before the release grid.',
+  ),
+  pairing(
+    'playlist-pitch',
+    'v2_stadium_poster',
+    'v2_pitch_room',
+    'Frame the carousel as a playlist-placement pitch with a clear save cue.',
+  ),
+  pairing(
+    'writer-credit',
+    'v2_rope_overture',
+    'v2_writer_board',
+    'Give songwriter credit visible space before the closing save reminder.',
+  ),
+  pairing(
+    'weekly-recap',
+    'v2_sunburst_countdown',
+    'v2_recap_wall',
+    'Use the recap wall for dense weeks and keep the opening title count-forward.',
+  ),
+];
+
+export const PHASE8_TEMPLATE_PAIRING_IDS = PHASE8_TEMPLATE_PAIRING_SCAFFOLD
+  .map(item => item.id);
+
+export const PHASE8_TEMPLATE_PAIRING_BODY_IDS = PHASE8_TEMPLATE_PAIRING_SCAFFOLD
+  .map(item => item.bodyTemplateId);
+
+export const PHASE8_TEMPLATE_PAIRING_TITLE_IDS = PHASE8_TEMPLATE_PAIRING_SCAFFOLD
+  .map(item => item.titleTemplateId);
+
+export function isPhase8PairingResolvable(pairingItem: Phase8TemplatePairingScaffold): boolean {
+  return PHASE7_CURATOR_BODY_TEMPLATE_IDS.includes(pairingItem.bodyTemplateId)
+    && PHASE4_TITLE_TEMPLATE_IDS.includes(pairingItem.titleTemplateId)
+    && pairingItem.closingTemplateId === PHASE5_CLOSING_TEMPLATE_PRESET.id;
+}

--- a/tests/unit/canvas-renderer-v2.test.ts
+++ b/tests/unit/canvas-renderer-v2.test.ts
@@ -47,6 +47,13 @@ import {
   PHASE7_CURATOR_BODY_TEMPLATE_SCAFFOLD,
   PHASE7_LIVE_BODY_TEMPLATE_PRESETS,
 } from '../../src/lib/body-templates-v2-phase7';
+import {
+  isPhase8PairingResolvable,
+  PHASE8_TEMPLATE_PAIRING_BODY_IDS,
+  PHASE8_TEMPLATE_PAIRING_IDS,
+  PHASE8_TEMPLATE_PAIRING_SCAFFOLD,
+  PHASE8_TEMPLATE_PAIRING_TITLE_IDS,
+} from '../../src/lib/template-pairings-v2-phase8';
 
 describe('canvas renderer v2 phase 1 surface', () => {
   it('normalizes design zip dash IDs to production-safe underscore IDs', () => {
@@ -208,5 +215,25 @@ describe('canvas renderer v2 phase 1 surface', () => {
       expect.arrayContaining(PHASE7_CURATOR_BODY_TEMPLATE_IDS),
     );
     expect(getV2BodyTemplatePreset(getTemplate('v2_writer_board'))?.fonts.script).toBe(NMF_BRAND_TOKENS.font.script);
+  });
+
+  it('scaffolds Phase 8 title/body/closing pairings without activating runtime visibility', () => {
+    expect(PHASE8_TEMPLATE_PAIRING_IDS).toEqual([
+      'phase8_discovery-stack',
+      'phase8_playlist-pitch',
+      'phase8_writer-credit',
+      'phase8_weekly-recap',
+    ]);
+    expect(PHASE8_TEMPLATE_PAIRING_BODY_IDS).toEqual(PHASE7_CURATOR_BODY_TEMPLATE_IDS);
+    expect(PHASE8_TEMPLATE_PAIRING_TITLE_IDS).toEqual([
+      'v2_script_spotlight',
+      'v2_stadium_poster',
+      'v2_rope_overture',
+      'v2_sunburst_countdown',
+    ]);
+    expect(PHASE8_TEMPLATE_PAIRING_SCAFFOLD.every(item => item.readyForPhase8Activation)).toBe(true);
+    expect(PHASE8_TEMPLATE_PAIRING_SCAFFOLD.every(item => !item.liveInPhase8)).toBe(true);
+    expect(PHASE8_TEMPLATE_PAIRING_SCAFFOLD.every(item => item.editorialCue.length > 20)).toBe(true);
+    expect(PHASE8_TEMPLATE_PAIRING_SCAFFOLD.every(isPhase8PairingResolvable)).toBe(true);
   });
 });


### PR DESCRIPTION
Builds on Phase 7 / PR #39. Opened as a stacked scaffold PR because local §13A still blocks `gh pr merge`; Strategy can backstop #39 first, then retarget or merge this Phase 8 scaffold per pattern.

[pre-ack-request] Strategy ratify-go in Wave 8 continuation. Scope: NMF Phase 8 template pairing scaffold.

Changes:
- Adds `template-pairings-v2-phase8.ts` with non-live title/body/closing journey pairings.
- Maps Phase 7 curator body templates to existing Phase 4 title templates and the Phase 5 closing slide.
- Adds resolver coverage to prove all Phase 8 pairings reference existing template IDs.

Verification:
- `rg -n "#[0-9A-Fa-f]{3,8}|rgba?\(" src/lib/template-pairings-v2-phase8.ts` -> no matches
- `git diff -U0 -- src/lib/template-pairings-v2-phase8.ts tests/unit/canvas-renderer-v2.test.ts | rg -n "^\+.*(#[0-9A-Fa-f]{3,8}|rgba?\()"` -> no matches
- `npm test -- --run tests/unit/canvas-renderer-v2.test.ts` -> 1 file passed, 17 tests passed
- `npm test` -> 41 files passed, 535 tests passed
- `npm run build` -> pass
- `git diff --check` -> pass
